### PR TITLE
MTL-1535 Fix set-efi-bbs.sh for GigaByte

### DIFF
--- a/boxes/ncn-common/files/scripts/metal/install-bootloader.sh
+++ b/boxes/ncn-common/files/scripts/metal/install-bootloader.sh
@@ -23,11 +23,13 @@ done
 
 # Install grub2.
 name=$(grep PRETTY_NAME /etc/*release* | cut -d '=' -f2 | tr -d '"')
-[ -z "$name" ] && name='CRAY Linux'
+index=0
+[ -z "$name" ] & name='CRAY Linux'
 for disk in $(mdadm --detail $(blkid -L $fslabel) | grep /dev/sd | awk '{print $NF}'); do
     # Add '--suse-enable-tpm' to grub2-install once we need TPM.
     grub2-install --no-rs-codes --suse-force-signed --root-directory $working_path --removable "$disk"
-    efibootmgr -c -D -d "$disk" -p 1 -L "cray ($(basename $disk))" -l '\efi\boot\bootx64.efi' | grep cray
+    efibootmgr -c -D -d "$disk" -p 1 -L "CRAY UEFI OS $index" -l '\efi\boot\bootx64.efi' | grep CRAY
+    index=$(($index + 1))
 done
 
 # Get the kernel command we used to boot.

--- a/boxes/ncn-common/files/scripts/metal/set-efi-bbs.sh
+++ b/boxes/ncn-common/files/scripts/metal/set-efi-bbs.sh
@@ -6,12 +6,11 @@
 # Set to 1 to skip enforcing the order, but still cleanup the boot menu.
 # This will let the order fall into however the BIOS wants it; grouping netboot, disk, and removable options.
 export no_enforce=0
-
+export efibootmgr_prefix=''
 cat << EOM
 ${0:-$(whoami)} is enforcing boot order ...
 these use the same commands from the manual page ...
-    internal site: https://stash.us.cray.com/projects/mtl/repos/docs-non-compute-nodes/browse/101-NCN-BOOTING.md#setting-order
-    external site: https://github.com/Cray-HPE/docs-csm-install/blob/main/101-NCN-BOOTING.md#setting-order
+    GitHub docs: https://github.com/Cray-HPE/docs-csm/blob/main/101-NCN-BOOTING.md#setting-order
 EOM
 
 (
@@ -31,7 +30,8 @@ function remove {
 }
 
 function enforce {
-    echo enforcing boot order $(cat /tmp/bbs*) && efibootmgr -o 0000,$(cat /tmp/bbs* | sed 's/^Boot//g' | awk '{print $1} ' | tr -d '*' | tr -d '\n' | sed -r 's/(.{4})/\1,/g;s/,$//') | grep -i bootorder
+    echo enforcing boot order $(cat /tmp/bbs*) && efibootmgr -o $efibootmgr_prefix$(cat /tmp/bbs* | sed 's/^Boot//g' | awk '{print $1} ' | tr -d '*' | tr -d '\n' | sed -r 's/(.{4})/\1,/g;s/,$//'),$(cat /tmp/rbbs* | sed 's/^Boot//g' | awk '{print $1} ' | tr -d '*' | tr -d '\n' | sed -r 's/(.{4})/\1,/g;s/,$//') | grep -i bootorder
+    echo activating boot entries && cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | xargs -r -i efibootmgr -b {} -a
 }
 
 # uses /tmp/rbbs99
@@ -68,32 +68,37 @@ case $vendor in
         # Removal file(s) ...
         efibootmgr | grep -ivP '(pxe ipv?4.*)' | grep -iP '(adapter|connection|nvme|sata)' | tee /tmp/rbbs1
         efibootmgr | grep -iP '(pxe ipv?4.*)' | grep -i connection | tee /tmp/rbbs2
+        efibootmgr | grep 'EFI Shell' | tee /tmp/rbbs3
+	efibootmgr_prefix=''
         trim
         specials
         remove
         case $hostname in
-        ncn-m*)
-            efibootmgr | grep -iP '(pxe ipv?4.*adapter)' | tee /tmp/bbs1
-            efibootmgr | grep cray | tee /tmp/bbs2
-            ;;
-        ncn-s*)
-            efibootmgr | grep -iP '(pxe ipv?4.*adapter)' | tee /tmp/bbs1
-            efibootmgr | grep cray | tee /tmp/bbs2
-            ;;
-        ncn-w*)
-            efibootmgr | grep -iP '(pxe ipv?4.*adapter)' | tee /tmp/bbs1
-            efibootmgr | grep cray | tee /tmp/bbs2
-            ;;
-        *)
-            fail_host
-            ;;
+            ncn-m*)
+                efibootmgr | grep -iP '(pxe ipv?(4|6).*adapter)' | tee /tmp/bbs1
+                efibootmgr | grep cray | tee /tmp/bbs2
+                efibootmgr | grep 'UEFI OS' | tee /tmp/bbs3
+                ;;
+            ncn-s*)
+                efibootmgr | grep -iP '(pxe ipv?(4|6).*adapter)' | tee /tmp/bbs1
+                efibootmgr | grep cray | tee /tmp/bbs2
+                efibootmgr | grep 'UEFI OS' | tee /tmp/bbs3
+                ;;
+            ncn-w*)
+                efibootmgr | grep -iP '(pxe ipv?(4|6).*adapter)' | tee /tmp/bbs1
+                efibootmgr | grep cray | tee /tmp/bbs2
+                efibootmgr | grep 'UEFI OS' | tee /tmp/bbs3
+                ;;
+            *)
+                fail_host
+                ;;
         esac
         ;;
     *Marvell*|HP|HPE)
         # Removal file(s) ...
         efibootmgr | grep -vi 'pxe ipv4' | grep -i adapter |tee /tmp/rbbs1
         efibootmgr | grep -iP '(sata|nvme)' | tee /tmp/rbbs2
-        no_enforce=1
+	    efibootmgr_prefix='0000,'
         trim
         specials
         remove
@@ -119,6 +124,7 @@ case $vendor in
         # Removal file(s) ...
         efibootmgr | grep -vi 'ipv4' | grep -iP '(sata|nvme|uefi)' | tee /tmp/rbbs1
         efibootmgr | grep -i baseboard | tee /tmp/rbbs2
+     	efibootmgr_prefix=''
         trim
         specials
         remove


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1535 (CSM 1.0)

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

This PR adjusts behaviors of the cloud-init bootorder script.
- Cease prepending `0000` to all node vendors. This was prepended harmlessly for Intels, and intently for HPE vendors where having it prevents the reverting of the bootorder by the iLO Governor. Incidentally this prevents GigaBytes from setting (see error below this bullet). This was fixed by included a new `efibootmgr_prefix` variable, that is set only when a `GigaByte` vendor is detected. 
```bash
/srv/cray/scripts/metal/set-efi-bbs.sh is enforcing boot order ...
--
these use the same commands from the manual page ...
internal site: https://stash.us.cray.com/projects/mtl/repos/docs-non-compute-nodes/browse/101-NCN-BOOTING.md#setting-order
external site: https://github.com/Cray-HPE/docs-csm-install/blob/main/101-NCN-BOOTING.md#setting-order
Invalid BootOrder order entry value0000
^
efibootmgr: entry 0000 does not exist
log file located at /var/log/metal-efi-bbs.log
```
- GigaByte nodes will also revert the bootorder following a reboot if not all available options exist within the `BootOrder` list (printed by `efibootmgr | grep -i bootorder`). This PR adjusts that behavior, so that all items are indeed included. To do so, IPv6 interfaces had to also be scanned for by the GigaByte parser section.
-  **NOTE** This PR is mainly to update the online code so it is consistent, as we do give links out (I do at least) to files in this repository. **There are no new 1.0 images, this code will not be built into an image that we ship for 1.0.X**.
<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)
- [ ] I have tested this on Intel server(s)
- [x] I have tested this on GigaByte server(s)
- [ ] I have tested this on Hewlett-Packard Enterprise server(s)

#### Idempotency
 
Yes.<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
None.<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
