### PR TITLE
CASMINST-3539 Add check to validate script runs on ncn-m001

### DIFF
--- a/boxes/ncn-node-images/k8s/files/scripts/join-spire-on-storage.sh
+++ b/boxes/ncn-node-images/k8s/files/scripts/join-spire-on-storage.sh
@@ -6,6 +6,11 @@ RETRY=0
 MAX_RETRIES=30
 RETRY_SECONDS=10
 
+if [ $(hostname) != "ncn-m001" ]; then
+  echo "$0 is designed to run on ncn-m001. If this is a different node then there is no reason for this to try to join storage nodes to spire. Exiting."
+  exit 1
+fi
+
 until kubectl exec -itn spire spire-server-0 --container spire-server -- ./bin/spire-server healthcheck | grep -q 'Server is healthy'; do
     if [[ "$RETRY" -lt "$MAX_RETRIES" ]]; then
         RETRY="$((RETRY + 1))"


### PR DESCRIPTION
#### Summary and Scope

- Fixes [CASMINST-3539](https://connect.us.cray.com/jira/browse/CASMINST-3539)
- 
##### Issue Type

- Bugfix Pull Request

This adds a check to the join-spire-on-storage.sh script to only attempt to join the storage nodes from ncn-m001. If this isn't here then it'll cause a 5 minute boot delay on any NCNs that boot up prior to spire-server being available.

#### Prerequisites

- [X] I tested this on internal system (x) (if yes, please include results or a description of the test)
 
Validated that the new check works.

#### Idempotency
 
Script won't attempt to join a storage node that's already joined.

#### Risks and Mitigations
 
If a node with the hostname ncn-m001 never starts then this script won't run and the storage nodes will never get joined to spire without manual intervention.