### PR TITLE
Add platform-utils rpm to metal-lib.sh (missed from 1.0)

### DIFF
--- a/boxes/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/boxes/ncn-common/files/scripts/metal/metal-lib.sh
@@ -443,5 +443,7 @@ function install_csm_rpms() {
         | jq -r  '.items[] | .assets[] | .downloadUrl' | grep goss-servers | sort -V | tail -1)
     csm_testing_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-sle-15sp2" \
         | jq -r  '.items[] | .assets[] | .downloadUrl' | grep csm-testing | sort -V | tail -1)
-    zypper install -y $goss_servers_url $csm_testing_url && systemctl enable goss-servers && systemctl restart goss-servers
+    platform_utils_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-sle-15sp2" \
+        | jq -r  '.items[] | .assets[] | .downloadUrl' | grep platform-utils | sort -V | tail -1)
+    zypper install -y $goss_servers_url $csm_testing_url $platform_utils_url && systemctl enable goss-servers && systemctl restart goss-servers
 }


### PR DESCRIPTION
#### Summary and Scope

- Fixes CASMINST-3538

##### Issue Type

- Bugfix Pull Request

Adding platform-utils back in metal-lib.sh for 1.2

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (wasp)

Code change finds rpm on wasp:

https://packages.local/repository/csm-sle-15sp2/noarch/platform-utils-1.2.4-1.noarch.rpm
 
#### Idempotency
 
N/A
 
#### Risks and Mitigations
 
N/A
