### PR TITLE
Update k8s to 1.20.12 for CVE-2020-28852 fix

### DIFF
--- a/boxes/ncn-node-images/k8s/files/resources/common/vars.sh
+++ b/boxes/ncn-node-images/k8s/files/resources/common/vars.sh
@@ -4,7 +4,7 @@
 # build and runtime scripts.
 #
 export KUBERNETES_PULL_PREVIOUS_VERSION="1.19.9"
-export KUBERNETES_PULL_VERSION="1.20.11"
+export KUBERNETES_PULL_VERSION="1.20.12"
 export KUBE_CONTROLLER_PREVIOUS_IMAGE="cray/kube-controller-manager:v${KUBERNETES_PULL_PREVIOUS_VERSION}"
 export KUBE_CONTROLLER_IMAGE="cray/kube-controller-manager:v${KUBERNETES_PULL_VERSION}"
 export WEAVE_VERSION="2.8.1"


### PR DESCRIPTION
#### Summary and Scope

- Fixes https://connect.us.cray.com/jira/browse/CASMINST-3564

##### Issue Type

- Bugfix Pull Request

Bump patch version for 1.2 to pull in fix for CVE-2020-28852

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)

Smoke tested in craystack:

```
ncn-m001:~ # kubectl get nodes
NAME       STATUS   ROLES                  AGE   VERSION
ncn-m001   Ready    control-plane,master   46m   v1.20.12
ncn-m002   Ready    control-plane,master   48m   v1.20.12
ncn-m003   Ready    control-plane,master   46m   v1.20.12
ncn-w001   Ready    <none>                 46m   v1.20.12
ncn-w002   Ready    <none>                 46m   v1.20.12
ncn-w003   Ready    <none>                 46m   v1.20.12
```
 
#### Idempotency
 
N/A
 
#### Risks and Mitigations
 
Low risk
