### PR TITLE
CASMINST-3568 - Improvements to ceph auto expand/rebuild

### DIFF
--- a/boxes/ncn-node-images/ceph/files/scripts/common/join_ceph_cluster.sh
+++ b/boxes/ncn-node-images/ceph/files/scripts/common/join_ceph_cluster.sh
@@ -6,65 +6,143 @@ host=$(hostname)
 
 > ~/.ssh/known_hosts
 
-for node in ncn-s001 ncn-s002 ncn-s003; do
-  ssh-keyscan -H "$node" >> ~/.ssh/known_hosts
-  pdsh -w $node > ~/.ssh/known_hosts
-  if [[ "$host" == "$node" ]]; then
-    continue
-  fi
+/srv/cray/scripts/common/pre-load-images.sh
 
-  if [[ $(nc -z -w 10 $node 22) ]] || [[ $counter -lt 3 ]]
+function gather_ceph_conf () {
+  FSID=$(pdsh -w $node -N 'ceph -s --format=json-pretty|jq -r .fsid')
+  WAS_MON=$(pdsh -w $node -N ceph node ls|jq -r --arg h $host 'any(.mon|keys; .[] == $h)')
+  WAS_OSD=$(pdsh -w $node -N ceph node ls|jq -r --arg h $host 'any(.osd|keys; .[] == $h)')
+  if $WAS_OSD
   then
-    if [[ "$host" =~ ^("ncn-s001"|"ncn-s002"|"ncn-s003")$ ]]
-    then
-      scp $node:/etc/ceph/* /etc/ceph
-    else
-      scp $node:/etc/ceph/rgw.pem /etc/ceph/rgw.pem
-    fi
-
-    if [[ ! $(pdsh -w $node "/srv/cray/scripts/common/pre-load-images.sh; ceph orch host rm $host; ceph cephadm generate-key; ceph cephadm get-pub-key > ~/ceph.pub; ssh-keyscan -H $host >> ~/.ssh/known_hosts ;ssh-copy-id -f -i ~/ceph.pub root@$host; ceph orch host add $host") ]]
-    then
-      (( counter+1 ))
-      if [[ $counter -ge 3 ]]
-      then
-        echo "Unable to access ceph monitor nodes"
-        exit 1
-      fi
-    else
-      break
-    fi
+    OSDS+=($(pdsh -w $node -N "ceph osd ls-tree $host"))
   fi
-done
+  CONF=$(pdsh -w $node -N ceph config generate-minimal-conf)
+  echo "fsid $FSID"
+  echo "OSDS ${OSDS[@]}"
+  echo "WAS_MON $WAS_MON"
+  echo "WAS_OSD $WAS_OSD"
+
+}
+
+function apply_ceph_conf () {
+  if [[ -n $WAS_OSD ]]
+  then
+    if [[ ! -d /var/lib/ceph/$FSID ]]
+    then
+      mkdir /var/lib/ceph/$FSID
+    fi
+    for osd in ${OSDS[@]}
+    do
+      if [[ ! -d /var/lib/ceph/$FSID/osd.$osd ]]
+      then
+       mkdir /var/lib/ceph/$FSID/osd.$osd
+      fi
+      echo "$CONF" > /var/lib/ceph/$FSID/osd.$osd/config
+    done
+  fi
+}
+
+(( loop_counter=0 ))
+(( counter_a=0 ))
+
+for node in ncn-s001 ncn-s002 ncn-s003; do
+
+  if [[ $counter -eq 0 ]] && nc -z -w 10 $node 22 
+    then
+      ssh-keyscan -H "$node" >> ~/.ssh/known_hosts
+      if [[ "$host" =~ ^("ncn-s001"|"ncn-s002"|"ncn-s003")$ ]] && [[ "$host" != "$node" ]]
+      then
+        scp $node:/etc/ceph/* /etc/ceph
+      else
+        scp $node:/etc/ceph/rgw.pem /etc/ceph/rgw.pem
+      fi
+
+      gather_ceph_conf
+      apply_ceph_conf
+
+      if $WAS_OSD
+      then
+        if [[ $counter_a -eq 0 ]] && [[ $(pdsh -w $node -N "ceph orch host rm $host") ]]
+        then
+          (( counter_a+=1 ))
+        fi
+      fi
+
+      if $WAS_MON
+      then
+	pdsh -w $node -N "ceph mon rm $host"
+      fi
+
+      if [[ ! $(pdsh -w $node "ceph cephadm generate-key; ceph cephadm get-pub-key > ~/ceph.pub; ssh-keyscan -H $host >> ~/.ssh/known_hosts ;ssh-copy-id -f -i ~/ceph.pub root@$host; ceph orch host add $host") ]]
+      then
+        if [[ "$node" =~ "ncn-s003" ]]
+        then
+          echo "Unable to access ceph monitor nodes"
+          exit 1
+        else
+          continue
+        fi
+      else
+        (( counter+=1 ))
+      fi
+  fi
 
 sleep 30
-(( ceph_mgr_failed_restarts=0 ))
-(( ceph_mgr_successful_restarts=0 ))
-until [[ $(cephadm shell -- ceph-volume inventory --format json-pretty|jq '.[] | select(.available == true) | .path' | wc -l) == 0 ]]
-do
-  for node in ncn-s001 ncn-s002 ncn-s003; do
-    if [[ $ceph_mgr_successful_restarts > 10 ]]
-    then
-      echo "Failed to bring in OSDs, manual troubleshooting required."
-      exit 1
-    fi
-    if pdsh -w $node ceph mgr fail
-    then
-      (( ceph_mgr_successful_restarts+1 ))
-      sleep 120
-      break
-    else
-      (( ceph_mgr_failed_restarts+1 ))
-      if [[ $ceph_mgr_failed_restarts -ge 3 ]]
+
+if ! $WAS_OSD
+then
+  (( ceph_mgr_failed_restarts=0 ))
+  (( ceph_mgr_successful_restarts=0 ))
+  until [[ $(cephadm shell -- ceph-volume inventory --format json-pretty|jq '.[] | select(.available == true) | .path' | wc -l) == 0 ]]
+  do
+      if [[ $ceph_mgr_successful_restarts > 10 ]]
       then
-        echo "Unable to access ceph monitor nodes."
+        echo "Failed to bring in OSDs, manual troubleshooting required."
         exit 1
       fi
-    fi
+      if pdsh -w $node ceph mgr fail
+      then
+        (( ceph_mgr_successful_restarts+1 ))
+        sleep 120
+        break
+      else
+        (( ceph_mgr_failed_restarts+1 ))
+        if [[ $ceph_mgr_failed_restarts -ge 3 ]]
+        then
+          echo "Unable to access ceph monitor nodes."
+          exit 1
+        fi
+      fi
   done
+fi
+
+if $WAS_OSD
+then
+    if [[ "$host" != "$node" ]]
+    then
+      active_mgr=$(pdsh -w $node -N "ceph mgr dump|jq -r '.active_name'")
+      pdsh -w $node ceph mgr fail
+      until [[ "$active_mgr" != $(pdsh -w $node "ceph mgr dump|jq '.active_name'") ]]
+      do
+         sleep 15
+      done
+      for osd in ${OSDS[@]}
+      do
+         echo "redeploying osd.$osd"
+         pdsh -w $node -N "ceph orch daemon redeploy osd.$osd"
+         (( loop_counter+=1 ))
+         sleep 5
+     done
+     if [[ $loop_counter -ge 1 ]]
+     then
+       break
+     fi
+  fi
+fi
+echo “loop counter: $loop_counter”
 done
 
-for service in $(cephadm ls | jq -r '.[].systemd_unit')
+for service in $(cephadm ls | jq -r '.[].systemd_unit'|grep -v cephadm)
 do
   systemctl enable $service
 done
-

--- a/boxes/ncn-node-images/ceph/files/scripts/metal/lib-1.5.sh
+++ b/boxes/ncn-node-images/ceph/files/scripts/metal/lib-1.5.sh
@@ -291,6 +291,10 @@ function init() {
     ssh $host '/srv/cray/scripts/metal/generate_haproxy_cfg.sh > /etc/haproxy/haproxy.cfg; systemctl enable haproxy.service; systemctl restart haproxy.service'
   done
 
+  # Enable Ceph device monitoring
+  ceph device monitoring on
+  ceph config set global device_failure_prediction_mode local
+
 }
 
 function get_ceph_config() {

--- a/boxes/ncn-node-images/k8s/files/resources/common/vars.sh
+++ b/boxes/ncn-node-images/k8s/files/resources/common/vars.sh
@@ -4,7 +4,7 @@
 # build and runtime scripts.
 #
 export KUBERNETES_PULL_PREVIOUS_VERSION="1.19.9"
-export KUBERNETES_PULL_VERSION="1.20.11"
+export KUBERNETES_PULL_VERSION="1.20.12"
 export KUBE_CONTROLLER_PREVIOUS_IMAGE="cray/kube-controller-manager:v${KUBERNETES_PULL_PREVIOUS_VERSION}"
 export KUBE_CONTROLLER_IMAGE="cray/kube-controller-manager:v${KUBERNETES_PULL_VERSION}"
 export WEAVE_VERSION="2.8.1"


### PR DESCRIPTION
#### Summary and Scope
Includes:
- Fixes to the join_ceph_cluster.sh script to avoid extra iterations
- Fixes to address if the ceph node is a designated a ceph-mon node
- Additional ceph device monitoring to allow for failure prediction

- Fixes # CASMINST-3568

##### Issue Type

- improvement

This is to support the storage node for expansion and/or rebuild in place.  It enables the node to run a script via cfs or a runcmd to join the ceph cluster as a new or existing node.  If it is an existing node it will utilize present lvms on the OSDs so we do not have to wipe those if we are just rebuilding in place.  This should also help cut down the time of the image based upgrade.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required) - Not required at this time.
- [x] I tested this on internal system - Cray stack
 
#### Idempotency
 This will only redeploy existing services if accidentally run
 
#### Risks and Mitigations
 
This is not run automatically.  so poses not risk.  
