### PR TITLE
MTL-1553: explicitly start lldpad

### DIFF
--- a/boxes/ncn-common/provisioners/common/install.sh
+++ b/boxes/ncn-common/provisioners/common/install.sh
@@ -25,7 +25,7 @@ systemctl enable wickedd-dhcp6.service
 systemctl enable wickedd-nanny.service
 systemctl enable getty@tty1.service
 systemctl enable serial-getty@ttyS0.service
-systemctl enable lldpad.service
+systemctl enable --now lldpad.service
 systemctl disable postfix.service && systemctl stop postfix.service
 systemctl enable chronyd.service
 systemctl enable spire-agent.service


### PR DESCRIPTION
#### Summary and Scope

The SSHOT-supplied lldpad automatically started the lldpad service.
With the SSHOT software removed from NCNs, we need to start it
explicitly.

- Fixes MTL-1553

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)

Smoke tested on redbull.  Booted from disk on redbull.

Requires: https://github.com/Cray-HPE/csm-rpms/pull/119