### PR TITLE
MTL-1566 Fix misaligned disk label for CRAYS3CACHE

### DIFF
--- a/boxes/ncn-node-images/k8s/files/resources/metal/cloud.cfg.d/01_metalfs.cfg
+++ b/boxes/ncn-node-images/k8s/files/resources/metal/cloud.cfg.d/01_metalfs.cfg
@@ -1,6 +1,6 @@
 #cloud-config
 fs_setup:
-    - label: CRAYS3FS
+    - label: CRAYS3CACHE
       filesystem: ext4
-      device: /dev/disk/by-id/dm-name-metalvg0-CRAYS3FS
+      device: /dev/disk/by-id/dm-name-metalvg0-CRAYS3CACHE
       partition: auto


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1566
- Relates to MTL-1462

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
This file is using CRAYS3FS when it should be using CRAYS3CACHE. With the misalignment the following error is seen in cloud-init and the drive is not formatted:
```bash
[  135.016353] cloud-init[11332]: Device /dev/disk/by-id/dm-name-metalvg0-CRAYS3FS did not exist and was not created with a udevadm settle.
```

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
