### PR TITLE
Add wait for s3fs secret before mounting directory

### DIFF
--- a/boxes/ncn-node-images/k8s/files/scripts/metal/lib.sh
+++ b/boxes/ncn-node-images/k8s/files/scripts/metal/lib.sh
@@ -154,6 +154,13 @@ function configure-s3fs-directory() {
 
   mkdir -p ${s3fs_mount_dir}
   pwd_file=/root/.${s3_user}.s3fs
+
+  until kubectl get secret ${s3_user}-s3-credentials > /dev/null 2>&1
+  do
+    sleep 5
+    echo "Waiting for storage node to create ${s3_user}-s3-credentials secret..."
+  done
+
   access_key=$(kubectl get secret ${s3_user}-s3-credentials -o json | jq -r '.data.access_key' | base64 -d)
   secret_key=$(kubectl get secret ${s3_user}-s3-credentials -o json | jq -r '.data.secret_key' | base64 -d)
   s3_endpoint=$(kubectl get secret ${s3_user}-s3-credentials -o json | jq -r '.data.http_s3_endpoint' | base64 -d)


### PR DESCRIPTION
#### Summary and Scope

Wait for secret to get created before mounting s3fs

- Fixes CASMINST-3614

##### Issue Types

- Bugfix Pull Request

Need secret before mount

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)
 
#### Idempotency
 
N/A
 
#### Risks and Mitigations

Low risk
