### PR TITLE
Delay s3fs bucket mounting until ceph is really done with rgw config

### DIFF
--- a/boxes/ncn-node-images/k8s/files/scripts/metal/lib.sh
+++ b/boxes/ncn-node-images/k8s/files/scripts/metal/lib.sh
@@ -155,16 +155,10 @@ function configure-s3fs-directory() {
   mkdir -p ${s3fs_mount_dir}
   pwd_file=/root/.${s3_user}.s3fs
 
-  until kubectl get secret ${s3_user}-s3-credentials > /dev/null 2>&1
+  until kubectl get cm ceph-csi-config > /dev/null 2>&1
   do
+    echo "Waiting for storage node to complete rgw configuration (waiting for ceph-csi-config configmap)..."
     sleep 5
-    echo "Waiting for storage node to create ${s3_user}-s3-credentials secret..."
-  done
-
-  until /opt/cray/platform-utils/s3/list-objects.py --bucket-name ${s3_bucket} > /dev/null 2>&1
-  do
-    sleep 5
-    echo "Waiting for storage node to create ${s3_bucket} bucket..."
   done
 
   access_key=$(kubectl get secret ${s3_user}-s3-credentials -o json | jq -r '.data.access_key' | base64 -d)


### PR DESCRIPTION
=#### Summary and Scope

- Fixes https://connect.us.cray.com/jira/browse/CASMTRIAGE-2764

##### Issue Type

- Bugfix Pull Request

We weren't sure if the recent s3fs changes where they immediately mount an s3fs dir as soon as the corresponding bucket is created, but by changing what the k8s nodes wait for (csi config map -- which occurs after all rgw config is done) seems to have fixed the issue.  Tested on redbull:

```
ncn-s001:~ # radosgw-admin buckets list
[
    "nmd",
    "badger",
    "postgres-backup",
    "ssi",
    "prs",
    "sls",
    "wlm",
    "ssm",
    "sds",
    "sat",
    "velero",
    "sma",
    "alc",
    "install-artifacts",
    "benji-backups",
    "vbis",
    "fw-update",
    "ssd",
    "ims",
    "etcd-backup",
    "boot-images"
]
```

```
ncn-w002:~ # mount | grep s3
/dev/mapper/metalvg0-CRAYS3CACHE on /var/lib/s3fs_cache type ext4 (rw,relatime)
s3fs on /var/lib/cps-local type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0
```

```
ncn-m002:~ # mount | grep s3
/dev/mapper/metalvg0-CRAYS3CACHE on /var/lib/s3fs_cache type ext4 (rw,relatime)
s3fs on /var/lib/sdu type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0
```

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)
 
#### Idempotency
 
N/A
 
#### Risks and Mitigations
 
Low risk -- already broken
