### PR TITLE
Add admin tools bucket and s3fs mount point on workers

### DIFF
--- a/boxes/ncn-node-images/ceph/files/resources/common/ansible/ceph-rgw-users/roles/ceph-rgw-users/defaults/main.yml
+++ b/boxes/ncn-node-images/ceph/files/resources/common/ansible/ceph-rgw-users/roles/ceph-rgw-users/defaults/main.yml
@@ -14,9 +14,7 @@ cray_sts_rgw_user: "{{ sts_rgw_user |default('STS') }}"
 cray_ims_rgw_user: "{{ ims_rgw_user |default('IMS') }}"
 cray_prs_rgw_user: "{{ prs_rgw_user |default('PRS') }}"
 cray_wlm_rgw_user: "{{ wlm_rgw_user |default('WLM') }}"
-cray_alc_rgw_user: "{{ als_rgw_user |default('ALC') }}"
-cray_vbis_rgw_user: "{{ vbis_rgw_user |default('VBIS') }}"
-cray_ssi_rgw_user: "{{ ssi_rgw_user |default('SSI') }}"
+cray_admin_tools_rgw_user: "{{ admin_tools_rgw_user |default('ADMIN-TOOLS') }}"
 cray_nmd_rgw_user: "{{ nmd_rgw_user |default('NMD') }}"
 cray_badger_rgw_user: "{{ badger_rgw_user |default('Badger') }}"
 cray_ssm_smw_rgw_user: "{{ ssm_smw_rgw_user |default('SSM-SWM') }}"
@@ -25,7 +23,6 @@ cray_cps_rgw_user: "{{ cps_rgw_user |default('CPS') }}"
 cray_bos_rgw_user: "{{ bos_rgw_user |default('BOS') }}"
 cray_bss_rgw_user: "{{ bss_rgw_user |default('BSS') }}"
 cray_etcd_backup_rgw_user: "{{ etcd_backup_rgw_user |default('Etcd-Backup') }}"
-cray_benji_backup_rgw_user: "{{ benji_backup_rgw_user |default('Benji-Backup') }}"
 cray_sls_rgw_user: "{{ sls_rgw_user |default('SLS') }}"
 cray_velero_rgw_user: "{{ sls_rgw_user |default('VELERO') }}"
 cray_sma_rgw_user: "{{ sma_rgw_user |default('SMA') }}"
@@ -74,14 +71,6 @@ ceph_rgw_users:
     policy_name: "{{ cray_sma_rgw_user }}_Policy"
     policy_action: "\"s3:*\""
     policy_resource: "\"arn:aws:s3:::sma\",\"arn:aws:s3:::sma/*\""
-
-  - user_name: "{{ cray_alc_rgw_user }}"
-    user_display_name: "Audit Log Collector User"
-    role_name: "{{ cray_alc_rgw_user }}"
-    role_arn: "arn:aws:iam:::user/{{ cray_alc_rgw_user }}"
-    policy_name: "{{ cray_alc_rgw_user }}_Policy"
-    policy_action: "\"s3:*\""
-    policy_resource: "\"arn:aws:s3:::alc\",\"arn:aws:s3:::alc/*\""
 
   - user_name: "{{ cray_etcd_backup_rgw_user }}"
     user_display_name: "Etcd Backup User"
@@ -132,21 +121,13 @@ ceph_rgw_users:
     policy_action: "\"s3:*\""
     policy_resource: "\"arn:aws:s3:::prs\",\"arn:aws:s3:::prs/*\""
 
-  - user_name: "{{ cray_vbis_rgw_user }}"
-    user_display_name: "Virtual Bastion Inception Server User"
-    role_name: "{{ cray_vbis_rgw_user }}"
-    role_arn: "arn:aws:iam:::user/{{ cray_vbis_rgw_user }}"
-    policy_name: "{{ cray_vbis_rgw_user }}_Policy"
+  - user_name: "{{ cray_admin_tools_rgw_user }}"
+    user_display_name: "Administrative Tools"
+    role_name: "{{ cray_admin_tools_rgw_user }}"
+    role_arn: "arn:aws:iam:::user/{{ cray_admin_tools_rgw_user }}"
+    policy_name: "{{ cray_admin_tools_rgw_user }}_Policy"
     policy_action: "\"s3:*\""
-    policy_resource: "\"arn:aws:s3:::vbis\",\"arn:aws:s3:::vbis/*\""
-
-  - user_name: "{{ cray_ssi_rgw_user }}"
-    user_display_name: "Virtual Bastion Inception Server User"
-    role_name: "{{ cray_ssi_rgw_user }}"
-    role_arn: "arn:aws:iam:::user/{{ cray_ssi_rgw_user }}"
-    policy_name: "{{ cray_ssi_rgw_user }}_Policy"
-    policy_action: "\"s3:*\""
-    policy_resource: "\"arn:aws:s3:::ssi\",\"arn:aws:s3:::ssi/*\""
+    policy_resource: "\"arn:aws:s3:::admin-tools\",\"arn:aws:s3:::admin-tools/*\""
 
   - user_name: "{{ cray_wlm_rgw_user }}"
     user_display_name: "WorkLoad Manager Service User"
@@ -196,15 +177,6 @@ ceph_rgw_users:
     policy_action: "\"s3:*\""
     policy_resource: "\"arn:aws:s3:::fw-update\",\"arn:aws:s3:::fw-update/*\""
 
-  - user_name: "{{ cray_benji_backup_rgw_user }}"
-    user_display_name: "Benji Backup User"
-    role_name: "{{ cray_benji_backup_rgw_user }}"
-    role_arn: "arn:aws:iam:::user/{{ cray_benji_backup_rgw_user }}"
-    policy_name: "{{ cray_benji_backup_rgw_user }}_Policy"
-    policy_action: "\"s3:*\""
-    policy_resource: "\"arn:aws:s3:::benji-backups\",\"arn:aws:s3:::benji-backups/*\""
-    additional_namespace: backups
-
   - user_name: "{{ cray_sls_rgw_user }}"
     user_display_name: "System Layout Service User"
     role_name: "{{ cray_sls_rgw_user }}"
@@ -247,12 +219,10 @@ ceph_rgw_buckets:
 
   - bucket_name: sds
     bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_sds_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::sds\",\"arn:aws:s3:::sds/*\"]}]}"
+    bucket_quota: "500G"
 
   - bucket_name: sma
     bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_sma_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::sma\",\"arn:aws:s3:::sma/*\"]}]}"
-
-  - bucket_name: alc
-    bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_alc_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::alc\",\"arn:aws:s3:::alc/*\"]}]}"
 
   - bucket_name: etcd-backup
     bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_etcd_backup_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::etcd-backup\",\"arn:aws:s3:::etcd-backup/*\"]}]}"
@@ -266,11 +236,9 @@ ceph_rgw_buckets:
   - bucket_name: prs
     bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_prs_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::prs\",\"arn:aws:s3:::prs/*\"]}]}"
 
-  - bucket_name: vbis
-    bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_vbis_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::vbis\",\"arn:aws:s3:::vbis/*\"]}]}"
-
-  - bucket_name: ssi
-    bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_ssi_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::ssi\",\"arn:aws:s3:::ssi/*\"]}]}"
+  - bucket_name: admin-tools
+    bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_admin_tools_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::admin-tools\",\"arn:aws:s3:::admin-tools/*\"]}]}"
+    bucket_quota: "500G"
 
   - bucket_name: wlm
     bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_wlm_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::wlm\",\"arn:aws:s3:::wlm/*\"]}]}"
@@ -286,9 +254,6 @@ ceph_rgw_buckets:
 
   - bucket_name: fw-update
     bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_fw_update_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::fw-update\",\"arn:aws:s3:::fw-update/*\"]}]}"
-
-  - bucket_name: benji-backups
-    bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_benji_backup_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::benji-backups\",\"arn:aws:s3:::benji-backups/*\"]}]}"
 
   - bucket_name: sls
     bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_sls_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::sls\",\"arn:aws:s3:::sls/*\"]}]}"

--- a/boxes/ncn-node-images/ceph/files/resources/common/ansible/ceph-rgw-users/roles/ceph-rgw-users/tasks/rgw_buckets.yml
+++ b/boxes/ncn-node-images/ceph/files/resources/common/ansible/ceph-rgw-users/roles/ceph-rgw-users/tasks/rgw_buckets.yml
@@ -40,3 +40,19 @@
   fail:
     msg: "Bucket {{ item.bucket_name }} was not created"
   when: s3_create.error is defined and s3_create.error.code != 'BucketAlreadyExists'
+
+- name: Set quota for {{ item.bucket_name }} bucket if specified
+  command: "radosgw-admin quota set --quota-scope=bucket --bucket={{ item.bucket_name }} --max-size={{ item.bucket_quota }}"
+  register: quota_set_bucket
+  until: quota_set_bucket.rc == 0 or quota_set_bucket.rc == 17
+  failed_when: quota_set_bucket.rc != 0 and quota_set_bucket.rc != 17
+  changed_when: quota_set_bucket.rc == 0
+  when: item.bucket_quota is defined
+
+- name: Enable quota for {{ item.user_name }} bucket if specified
+  command: "radosgw-admin quota enable --quota-scope=bucket --bucket={{ item.bucket_name }}"
+  register: quota_enable_bucket
+  until: quota_enable_bucket.rc == 0 or quota_enable_bucket.rc == 17
+  failed_when: quota_enable_bucket.rc != 0 and quota_enable_bucket.rc != 17
+  changed_when: quota_enable_bucket.rc == 0
+  when: item.bucket_quota is defined

--- a/boxes/ncn-node-images/k8s/files/scripts/common/kubernetes-cloudinit.sh
+++ b/boxes/ncn-node-images/k8s/files/scripts/common/kubernetes-cloudinit.sh
@@ -153,7 +153,7 @@ EOF
 function complete-initialization() {
   restart-daemons
   get-ceph-config $FIRST_STORAGE_HOSTNAME
-  configure-s3fs-directory
+  configure-s3fs
   mark-initialized
 }
 

--- a/boxes/ncn-node-images/k8s/files/scripts/google/lib.sh
+++ b/boxes/ncn-node-images/k8s/files/scripts/google/lib.sh
@@ -166,6 +166,6 @@ function expand-root-disk() {
   resize2fs /dev/sda2
 }
 
-function configure-s3fs-directory() {
-  echo "In configure-s3fs-directory()"
+function configure-s3fs() {
+  echo "In configure-s3fs()"
 }


### PR DESCRIPTION
#### Summary and Scope

- Fixes https://connect.us.cray.com/jira/browse/CASMINST-3627

##### Issue Type

- Bugfix Pull Request

Add admin-tools bucket for ssi and other admin tools (and s3fs mount point).  Also removing unused buckets (ssi, vbis, benji-backups). 

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)

Craystack:

```
ncn-s001:~ # radosgw-admin bucket list
[
    "nmd",
    "badger",
    "postgres-backup",
    "prs",
    "sls",
    "wlm",
    "ssm",
    "sds",
    "sat",
    "velero",
    "sma",
    "install-artifacts",
    "fw-update",
    "ssd",
    "admin-tools",
    "ims",
    "etcd-backup",
    "boot-images"
]
```

```
ncn-m001:/var/lib/admin-tools # mount | grep s3fs
s3fs on /var/lib/sdu type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0)
s3fs on /var/lib/admin-tools type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0)
```

```
ncn-w001:~ # mount | grep s3fs
s3fs on /var/lib/cps-local type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0)
```
#### Idempotency
 
Ran the ansible play multiple times
 
#### Risks and Mitigations
 
Low risk
