### PR TITLE
CASMINST-3650 - Fix for ceph-enable-services

### DIFF
--- a/boxes/ncn-node-images/storage-ceph/files/scripts/common/ceph-enable-services.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/common/ceph-enable-services.sh
@@ -2,9 +2,9 @@ function enable_ceph_systemd () {
   echo "Enabling all Ceph services to start on boot"
   for host in $(ceph node ls| jq -r '.osd|keys[]'); do
     echo "Enabling services on host: $host"
-    ssh "$host" 'for service in $(cephadm ls |jq -r .[].systemd_unit|grep $(ceph status -f json-pretty |jq -r .fsid));do echo "Enabling service $service on $(hostname)"; systemctl enable $service; done'
+    ssh "$host" 'for service in $(cephadm ls |jq -r .[].systemd_unit);do echo "Enabling service $service on $(hostname)"; systemctl enable $service; done'
     echo "Verifying services on host: $host"
-    output=$(ssh "$host" 'for service in $(cephadm ls |jq -r .[].systemd_unit|grep $(ceph status -f json-pretty |jq -r .fsid));do echo $service; systemctl is-enabled $service; done')
+    output=$(ssh "$host" 'for service in $(cephadm ls |jq -r .[].systemd_unit);do echo $service; systemctl is-enabled $service; done')
     cnt=0
     client_array=( $output )
     array_length=${#client_array[@]}


### PR DESCRIPTION
This will address the systemd_unit enable for cluster larger than 3

#### Summary and Scope
- Fixes CASMINST-3650

##### Issue Type
- Bugfix Pull Request

On nodes that do not have the credentials to run ceph commands the ceph enable script will not work.  

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (x) (if yes, please include results or a description of the test)
 
#### Idempotency
 
This is idempotent. 
#### Risks and Mitigations
 

