### PR TITLE
testing checkboxes for vshasta and metal

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,8 @@
 #### Prerequisites
 
 - [ ] I have included documentation in my PR (or it is not required)
-- [ ] I tested this on internal system (x) (if yes, please include results or a description of the test)
+- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
+- [ ] I tested this on vshastat (if yes, please include results or a description of the test)
  
 #### Idempotency
  


### PR DESCRIPTION
This change is strictly to the PR template.

The "internal system checkbox" was split-up into the two spheres we deliver for; metal, and vshasta.