### PR TITLE
Update labeler to run on these branches instead of a target since tha…

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,8 +1,9 @@
 name: "Pull Request Labeler"
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
+      - lts/csm-1.0
 
 jobs:
   release:


### PR DESCRIPTION
Update the labeler.

`pull_request_target` doesn't seem to apply the label to the existing, open PR. This changes it to run all the time against these branches.