### PR TITLE
MTL-1562 Take advantage of the stripe

### DIFF
--- a/boxes/ncn-node-images/k8s/files/resources/metal/cloud.cfg.d/00_metalfs_lvm.cfg
+++ b/boxes/ncn-node-images/k8s/files/resources/metal/cloud.cfg.d/00_metalfs_lvm.cfg
@@ -4,4 +4,4 @@
 bootcmd:
     - [cloud-init-per, once, create_PV, pvcreate, -ff, -y, -M, lvm2, /dev/md/AUX]
     - [cloud-init-per, once, create_VG, vgcreate, metalvg0, /dev/md/AUX]
-    - [cloud-init-per, once, create_LV_CRAYS3CACHE, lvcreate, -L, 100GB, -n, CRAYS3CACHE, metalvg0]
+    - [cloud-init-per, once, create_LV_CRAYS3CACHE, lvcreate, -L, 200GB, -n, CRAYS3CACHE, metalvg0]


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1562

##### Issue Type
<!--- Delete un-needed bullets -->

- RFE Pull Request

This change results in striping the final partition on each disk in the RAID.

_Before_:
- Partition 1: Mirror, FSLABEL=BOOTRAID
- Partition 2: Mirror, FSLABEL=SQFSRAID
- Partition 3: Mirror, FSLABEL=ROOTRAID
- Partition 4: Mirror, FSLABEL=AUX

_After_:

- Partition 1: Mirror, FSLABEL=BOOTRAID
- Partition 2: Mirror, FSLABEL=SQFSRAID
- Partition 3: Mirror, FSLABEL=ROOTRAID
- Partition 4: Stripe, FSLABEL=AUX

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required) https://github.com/Cray-HPE/docs-csm/pull/638
https://github.com/Cray-HPE/docs-csm/pull/639
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)
 

#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
Low risk. Installs & Upgrades will be able to wipe and adopt this without issue.