### PR TITLE
Remove nonempty option and change sdu mount point

### DIFF
--- a/boxes/ncn-node-images/k8s/files/scripts/metal/lib.sh
+++ b/boxes/ncn-node-images/k8s/files/scripts/metal/lib.sh
@@ -171,14 +171,14 @@ function configure-s3fs() {
   s3fs_cache_dir=/var/lib/s3fs_cache
 
   if [ -d ${s3fs_cache_dir} ]; then
-    s3fs_opts="use_path_request_style,use_cache=${s3fs_cache_dir},check_cache_dir_exist=true"
+    s3fs_opts="use_path_request_style,use_cache=${s3fs_cache_dir},check_cache_dir_exist"
    else
     s3fs_opts="use_path_request_style"
   fi
 
   if [[ "$(hostname)" =~ ^ncn-m ]]; then
-    sdu_opts="uid=2370,gid=2370,umask=0007,allow_other,nonempty"
-    configure-s3fs-directory sds sds /var/lib/sdu ${s3fs_cache_dir} "${s3fs_opts},${sdu_opts}"
+    sdu_opts="uid=2370,gid=2370,umask=0007,allow_other"
+    configure-s3fs-directory sds sds /var/opt/cray/sdu/collection-mount ${s3fs_cache_dir} "${s3fs_opts},${sdu_opts}"
     #
     # Set cache pruning for sdu to 100G (50%) of the 200G volume (five minutes after midnight)
     #


### PR DESCRIPTION
Also fix setting check_cache_dir_exist in prep for s3fs 1.90

#### Summary and Scope

- Fixes https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3667

##### Issue Type

- Bugfix Pull Request

Update sdu mount options per testing, fix option to check_cache_dir_exist (not used yet -- but will be when we have 1.90)

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [x] I tested this on vshasta (craystack)  (if yes, please include results or a description of the test)
 
```
ncn-m001:~ # mount | grep s3fs
s3fs on /var/opt/cray/sdu/collection-mount type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other)
s3fs on /var/lib/admin-tools type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0)
```

```
ncn-m001:~ # cat /etc/fstab | grep fuse
sds /var/opt/cray/sdu/collection-mount fuse.s3fs _netdev,allow_other,passwd_file=/root/.sds.s3fs,url=http://ncn-s001:8080,use_path_request_style,use_cache=/tmp,check_cache_dir_exist,uid=2370,gid=2370,umask=0007,allow_other 0 0
admin-tools /var/lib/admin-tools fuse.s3fs _netdev,allow_other,passwd_file=/root/.admin-tools.s3fs,url=http://ncn-s001:8080,use_path_request_style,use_cache=/tmp,check_cache_dir_exist 0 0
```
#### Idempotency
 
N/A
 
#### Risks and Mitigations
 
Low risk
