### PR TITLE
CASMPET-5208 - create and distribute a ceph read-only keyring

### DIFF
--- a/boxes/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/boxes/ncn-common/files/scripts/metal/metal-lib.sh
@@ -144,17 +144,19 @@ function get_boot_artifacts {
 
 function configure_lldp() {
     local interfaces
-    interfaces=`ls /sys/class/net/ | grep mgmt`
+    # Grab all bond interfaces and their members; mgmt and sun NICs. Remove duplicates from partial matches.
+    interfaces=`ls /sys/class/net/ | grep -oP '(mgmt|bond|sun)\d+' | sort -u`
+    systemctl is-active lldpad >/dev/null || systemctl start lldpad
     for i in $interfaces; do
-      echo "enabling and configuring LLDP for interface: $i"
+      echo "Configuring LLDP [$i] ..."
       lldptool set-lldp -i $i adminStatus=rxtx
-      lldptool -T -i $i -V  sysName enableTx=yes
-      lldptool -T -i $i -V  portDesc enableTx=yes
-      lldptool -T -i $i -V  sysDesc enableTx=yes
-      lldptool -T -i $i -V sysCap enableTx=yes
-      lldptool -T -i $i -V mngAddr enableTx=yes
+      printf '[%s] sysName ' $i && lldptool -T -i $i -V  sysName enableTx=yes
+      printf '[%s] portDesc ' $i && lldptool -T -i $i -V  portDesc enableTx=yes
+      printf '[%s] sysDesc ' $i && lldptool -T -i $i -V  sysDesc enableTx=yes
+      printf '[%s] sysCap ' $i && lldptool -T -i $i -V sysCap enableTx=yes
+      printf '[%s] mngAddr ' $i && lldptool -T -i $i -V mngAddr enableTx=yes
     done
-    echo 'enabling and configuring of LLDP is complete'
+    echo 'LLDP is configured for all bond interfaces and their members (mgmt and sun)'
 }
 
 function set_static_fallback() {

--- a/boxes/ncn-node-images/storage-ceph/files/scripts/common/storage-ceph-cloudinit.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/common/storage-ceph-cloudinit.sh
@@ -72,6 +72,12 @@ fi
 . /srv/cray/scripts/common/enable-ceph-mgr-modules.sh
 enable_ceph_prometheus
 
+# Make ceph read-only client for monitoring
+ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
+ceph auth import -i /etc/ceph/ceph.client.ro.keyring
+echo "Distributing the client.ro keyring"
+for node in $(ceph orch host ls --format=json|jq -r '.[].hostname'); do scp /etc/ceph/ceph.client.ro.keyring $node:/etc/ceph/ceph.client.ro.keyring; done
+
 # Wait for workers
 wait_for_k8s_worker
 


### PR DESCRIPTION
#### Summary and Scope
This will help address the ceph service checks and the patch to distribute the admin across all nodes

- Fixes # CASMPET-5208

##### Issue Type

- Bug/Security

This change creates a read-only ceph client for use with the ceph-services script.
The admin credentials were distributed across ceph hosts which is against best practices for ceph security. 

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
If run again, it will create and distribute a new keyring.  i.e. this is safe to run as many times as we want as long as the keyrings are distributed.  But really, this script should only run once at install and never again.  
 
#### Risks and Mitigations
 
