### PR TITLE
MTL-1583 lldpad not starting

### DIFF
--- a/boxes/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/boxes/ncn-common/files/scripts/metal/metal-lib.sh
@@ -144,17 +144,19 @@ function get_boot_artifacts {
 
 function configure_lldp() {
     local interfaces
-    interfaces=`ls /sys/class/net/ | grep mgmt`
+    # Grab all bond interfaces and their members; mgmt and sun NICs. Remove duplicates from partial matches.
+    interfaces=`ls /sys/class/net/ | grep -oP '(mgmt|bond|sun)\d+' | sort -u`
+    systemctl is-active lldpad >/dev/null || systemctl start lldpad
     for i in $interfaces; do
-      echo "enabling and configuring LLDP for interface: $i"
+      echo "Configuring LLDP [$i] ..."
       lldptool set-lldp -i $i adminStatus=rxtx
-      lldptool -T -i $i -V  sysName enableTx=yes
-      lldptool -T -i $i -V  portDesc enableTx=yes
-      lldptool -T -i $i -V  sysDesc enableTx=yes
-      lldptool -T -i $i -V sysCap enableTx=yes
-      lldptool -T -i $i -V mngAddr enableTx=yes
+      printf '[%s] sysName ' $i && lldptool -T -i $i -V  sysName enableTx=yes
+      printf '[%s] portDesc ' $i && lldptool -T -i $i -V  portDesc enableTx=yes
+      printf '[%s] sysDesc ' $i && lldptool -T -i $i -V  sysDesc enableTx=yes
+      printf '[%s] sysCap ' $i && lldptool -T -i $i -V sysCap enableTx=yes
+      printf '[%s] mngAddr ' $i && lldptool -T -i $i -V mngAddr enableTx=yes
     done
-    echo 'enabling and configuring of LLDP is complete'
+    echo 'LLDP is configured for all bond interfaces and their members (mgmt and sun)'
 }
 
 function set_static_fallback() {


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1583

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

This fixes two things:
1. It ensures lldpad is active; the daemon will start if it isn't already.
2. This enables and configures LLDP on mgmt, sun, and bond NICs.

Observe, ncn-s00[1-3] are reporting hostnames and advertising correctly _after_ enabling `adminStatus=rxtx` and `sysName enableTx=yes` on each NCN.

![image (1)](https://user-images.githubusercontent.com/7772179/146064483-db6c3cb2-0845-4ec4-94fe-49b7b932fc62.png)

```bash
sw-spine-001 [mlag-domain: master] # sh lldp remote
--------------------------------------------------------------------------------
Local Interface      Device ID            Port ID              System Name
--------------------------------------------------------------------------------
Eth1/1 (Mpo1)        b8:59:9f:fe:49:d4    b8:59:9f:fe:49:d4    Not Advertised
Eth1/2 (Mpo2)        b8:59:9f:f9:1c:8e    b8:59:9f:f9:1c:8e    Not Advertised
Eth1/3 (Mpo3)        b8:59:9f:fe:49:9c    b8:59:9f:fe:49:9c    Not Advertised
Eth1/4 (Mpo4)        b8:59:9f:fe:49:d8    b8:59:9f:fe:49:d8    Not Advertised
Eth1/5 (Mpo5)        b8:59:9f:fe:49:f0    b8:59:9f:fe:49:f0    Not Advertised
Eth1/6 (Mpo6)        0a:66:09:8a:08:00    b8:59:9f:f9:1c:7e    Not Advertised
Eth1/6 (Mpo6)        b8:59:9f:f9:1c:7e    b8:59:9f:f9:1c:7e    ncn-s001
Eth1/7 (Mpo7)        b8:59:9f:fe:49:ec    b8:59:9f:fe:49:ec    ncn-s002
Eth1/8 (Mpo8)        b8:59:9f:f9:1c:ba    b8:59:9f:f9:1c:ba    ncn-s003
Eth1/9 (Mpo9)        b8:59:9f:d9:9e:2c    b8:59:9f:d9:9e:2c    Not Advertised
Eth1/15 (Mpo151)     e4:f0:04:4d:e7:ec    ethernet1/1/52       sw-leaf-bmc-001
Eth1/16              f4:8e:38:55:c3:f6    TenGigabitEthernet 1/10 CFCANB1S1
``` 

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
