### PR TITLE
MTL-1588 Remove Risk of Connection Loss

### DIFF
--- a/boxes/ncn-common/files/scripts/metal/install.sh
+++ b/boxes/ncn-common/files/scripts/metal/install.sh
@@ -50,6 +50,17 @@ DHCPREQUESTs despite changing their IP source to STATIC.
 
 CONSOLES will cease working while the BMC is reset (8-20seconds).
 EOM
+    local vendor
+    vendor=$(ipmitool fru | grep -i 'board mfg' | tail -n 1 | cut -d ':' -f2 | tr -d ' ')
+    case $vendor in
+        *Marvell*|HP|HPE)
+            BMC_RESET='warm'
+            ;;
+        *)
+            # Use COLD reset by default; no error, since this will cold reset anything.
+            :
+            ;;
+    esac
     (
         set -x
         # One could `export BMC_RESET='warm'` to change the behavior here.


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1588

(Previously submitted as #139 but yanked out for a syntax error).

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

The cold reset is very harsh on servers where a warm reset is
sufficient. On HPE, a warm reset will kick-over DHCP/static IPsrcs and
return faster.

This change pivots HPE servers to always warm reset instead of cold
resetting.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
