### PR TITLE
CASMTRIAGE-2793 Disable Network Activation

### DIFF
--- a/boxes/ncn-common/files/resources/common/cloud.cfg
+++ b/boxes/ncn-common/files/resources/common/cloud.cfg
@@ -35,3 +35,5 @@ system_info:
         ssh_svcname: sshd
 manage_etc_hosts: template
 manage_resolv_conf: true
+disable_network_activation: true
+

--- a/boxes/ncn-common/files/resources/common/cloud/templates/cloud-init-network.tmpl
+++ b/boxes/ncn-common/files/resources/common/cloud/templates/cloud-init-network.tmpl
@@ -16,7 +16,8 @@ network:
       parameters:
         mode: 802.3ad
         mii-monitor-interval: 100
-        lacp-rate: fast
+        lacp-rate: slow
+        ad-select: bandwidth
         transmit-hash-policy: layer2+3
   vlans:
   {% for name, network in ds.meta_data.ipam.items() if network.vlanid != 0 %}


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Requires https://github.com/Cray-HPE/metal-ipxe/pull/26
- Relates to CASMTRIAGE-2793

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

cloud-init will attempt to UP the network during its own startup,
however the network is already UP at this point. The re-UP of the
network causes the NCN's bond to go down and then UP, this can affect
STP blocks on Arubas. Specifically we see STP blocks in storage nodes,
after they've booted successfully they may or may not actually start
cloud-init. In those cases cloud-init falls to a fallback datasource,
and becomes difficult to recover.

Testing yielded successful cloud-init runs on HPE systems with Arubas where previously cloud-init was struggling.
- surtur storage nodes all booted successfully, these had previously been flaking when cloud-init started _after_ using the CASMTRIAGE-2793 improvements
- surtur k8s nodes had no problems before and after this change

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
Since networking is already up, this is always idempotent. If networking is not up, there's a larger/different problem and cloud-init shouldn't be the focus.

#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
