### PR TITLE
Latest Pre-Release 0.2.35

### DIFF
--- a/boxes/ncn-common/files/scripts/metal/install.sh
+++ b/boxes/ncn-common/files/scripts/metal/install.sh
@@ -13,9 +13,9 @@ breakaway() {
     # clean bootstrap/ephemeral TCP/IP information
     (
         set -x
+        write_default_route
         clean_bogies
         drop_metal_tcp_ip bond0
-        write_default_route
     ) 2>/var/log/cloud-init-metal-breakaway.error
 }
 

--- a/boxes/ncn-common/files/scripts/metal/install.sh
+++ b/boxes/ncn-common/files/scripts/metal/install.sh
@@ -50,6 +50,17 @@ DHCPREQUESTs despite changing their IP source to STATIC.
 
 CONSOLES will cease working while the BMC is reset (8-20seconds).
 EOM
+    local vendor
+    vendor=$(ipmitool fru | grep -i 'board mfg' | tail -n 1 | cut -d ':' -f2 | tr -d ' ')
+    case $vendor in
+        *Marvell*|HP|HPE)
+            BMC_RESET='warm'
+            ;;
+        *)
+            # Use COLD reset by default; no error, since this will cold reset anything.
+            :
+            ;;
+    esac
     (
         set -x
         # One could `export BMC_RESET='warm'` to change the behavior here.

--- a/boxes/ncn-common/files/scripts/metal/net-init.sh
+++ b/boxes/ncn-common/files/scripts/metal/net-init.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
+function fail_and_die() {
+    echo >&2 ${1:-"$0 failed and is exiting"}
+    exit 1
+}
+
 set +e # Yes. This is a +e; this script is allowed to error.
 printf 'net-init: [ % -20s ]\n' 'starting net-init'
-
-printf 'net-init: [ % -20s ]\n' 'running: sysconfig'
-cloud-init query --format="$(cat /etc/cloud/templates/cloud-init-network.tmpl)" >/etc/cloud/cloud.cfg.d/00_network.cfg
 
 printf 'net-init: [ % -20s ]\n' 'running: netconfig'
 # FIXME: MTL-1439 Use the default resolv_conf module.
@@ -13,23 +15,37 @@ sed -i 's/NETCONFIG_DNS_POLICY=.*/NETCONFIG_DNS_POLICY=""/g' /etc/sysconfig/netw
 if [[ -f /etc/resolv.conf ]]; then
     rm /etc/resolv.conf
 fi
-cloud-init query --format="$(cat /etc/cloud/templates/resolv.conf.tmpl)" >/etc/resolv.conf
+cloud-init query --format="$(cat /etc/cloud/templates/resolv.conf.tmpl)" >/etc/resolv.conf || fail_and_die
 # Cease updating the default route; use the templated config files.
 sed -i 's/^DHCLIENT_SET_DEFAULT_ROUTE=.*/DHCLIENT_SET_DEFAULT_ROUTE="no"/' /etc/sysconfig/network/dhcp
 netconfig update -f
 
 # FIXME: MTL-1440 Use the default update_etc_hosts module.
 printf 'net-init: [ % -20s ]\n' 'running: hosts file'
-cloud-init query --format="$(cat /etc/cloud/templates/hosts.suse.tmpl)" >/etc/hosts
+cloud-init query --format="$(cat /etc/cloud/templates/hosts.suse.tmpl)" >/etc/hosts || fail_and_die
 
-printf 'net-init: [ % -20s ]\n' 'running: acclimating'
-# Run cloud-init again against our new network.cfg file.
-cloud-init clean
-cloud-init init
+# This function runs cloud-init commands twice;
+# once to generate the ifcfg files,
+# and again to reload cloud-init metadata after network daemons restart. 
+function ifconf() {
+    printf 'net-init: [ % -20s ]\n' 'running: sysconfig'
+    cloud-init query --format="$(cat /etc/cloud/templates/cloud-init-network.tmpl)" >/etc/cloud/cloud.cfg.d/00_network.cfg || fail_and_die
+    printf 'net-init: [ % -20s ]\n' 'running: acclimating'
 
-# Load our new configurations, or reload the daemon if nothing states it needs to be reloaded.
-printf 'net-init: [ % -20s ]\n' 'running: ifreload'
-wicked ifreload all || systemctl restart wicked
+    # PHASE 1: Invoke the generated template; generate the ifcfg files
+    cloud-init clean
+    cloud-init init
+
+    # FIXME: Understand why cloud-init doesn't fix this for us; what is "Running interface command ['systemctl', 'restart', 'systemd-networkd', 'systemd-resolved'] failed"
+    # Load our new configurations, or reload the daemon if nothing states it needs to be reloaded.
+    printf 'net-init: [ % -20s ]\n' 'running: ifreload'
+    wicked ifreload all
+
+    # PHASE 2: cloud-init local meta will be invalid now that our topology changed; re-init cloud-init
+    cloud-init clean
+    cloud-init init
+}
+ifconf
 
 # Checks whether IPs exist on all of our NICs or not.
 function check_ips() {
@@ -52,7 +68,7 @@ if [ ${error:-0} != 0 ]; then
     printf 'net-init: [ % -20s ]\n' 'quiesce: wickedd'
     systemctl restart wickedd-nanny
 fi
-# Sleep for 2 seconds to let weickedd-nanny startup, and then restart the
+# Sleep for 2 seconds to let wickedd-nanny startup, and then restart the
 # child-process specific to NIC handlers so they force loading the new configs.
 sleep 2
 if check_ips 1 ; then


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1407 MTL-1590 MTL-1588 MTL-1540 CASMPET-5208 MTL-1586
- Relates to CASMTRIAGE-2793

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This includes the following commits:
- dbbeb20 (HEAD -> develop, tag: 0.2.35-5, tag: 0.2.35-4, tag: 0.2.35-3, origin/develop, origin/MTL-1588-mc-reset-warm-for-HPE-only, origin/HEAD, MTL-1588-mc-reset-warm-for-HPE-only) MTL-1588 Remove Risk of Connection Loss
- 0c47963 (tag: 0.2.35-2, origin/MTL-1540-net-init-hardening, MTL-1540-net-init-hardening) MTL-1540 Always reload metadata and add fatal exit
- cd9e918 (tag: 0.2.34-1, tag: 0.2.34, tag: 0.2.33-4, tag: 0.2.33, origin/main, origin/CASMPET-5208, main, CASMPET-5208) Updating join script to fetch the client.ro keyring
- 53055fc CASMPET-5208 - create and distribute a ceph read-only keyring

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
