### PR TITLE
MTL-1591: Split kernel install to reduce cloud image size

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -33,7 +33,7 @@ pipeline {
         ARTIFACTS_DIRECTORY_COMMON = "output-ncn-common"
         ARTIFACTS_DIRECTORY_CEPH = "output-ncn-node-images/storage-ceph"
         ARTIFACTS_DIRECTORY_K8S = "output-ncn-node-images/kubernetes"
-        ISO_URL = "https://artifactory.algol60.net/artifactory/os-images/SLE-15-SP3-Full-x86_64-GM-Media1.iso"
+        ISO_URL = "https://artifactory.algol60.net/artifactory/os-images/SLE-15-SP3-Online-x86_64-GM-Media1.iso"
         STABLE_BASE = "https://artifactory.algol60.net/artifactory/csm-images/stable"
         NPROC = sh(returnStdout: true, script: "nproc").trim()
         NRAM = '4096'
@@ -103,7 +103,6 @@ pipeline {
 					script {
 						def arguments = "-only=qemu.sles15-base -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
 						publishCsmImages.build(arguments, 'boxes/sles15-base/')
-						publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_BASE, VERSION)
 					}
 				}
 			}

--- a/boxes/ncn-common/common.pkr.hcl
+++ b/boxes/ncn-common/common.pkr.hcl
@@ -134,6 +134,17 @@ build {
   }
 
   provisioner "shell" {
+    environment_vars = [
+      "SLES15_KERNEL_VERSION=${var.kernel_version}"
+    ]
+    script = "${path.root}/scripts/kernel-debug.sh"
+    only = [
+      "qemu.ncn-common",
+      "virtualbox-ovf.ncn-common"
+    ]
+  }
+
+  provisioner "shell" {
     script = "${path.root}/provisioners/metal/hpc.sh"
     only = [
       "qemu.ncn-common",

--- a/boxes/ncn-common/provisioners/common/setup.sh
+++ b/boxes/ncn-common/provisioners/common/setup.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-echo "Fixing Artifactory DNS"
-echo "34.120.105.219 artifactory.algol60.net" >> /etc/hosts
-
 echo "Initializing log location(s)"
 mkdir -p /var/log/cray
 cat << 'EOF' > /etc/logrotate.d/cray

--- a/boxes/ncn-common/scripts/kernel-debug.sh
+++ b/boxes/ncn-common/scripts/kernel-debug.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+KERNEL_PACKAGES=(kernel-default-debuginfo-"$SLES15_KERNEL_VERSION"
+kernel-default-debugsource-"$SLES15_KERNEL_VERSION")
+
+eval zypper --plus-content debug --non-interactive install --no-recommends --oldpackage "${KERNEL_PACKAGES[*]}"

--- a/boxes/ncn-common/variables.pkr.hcl
+++ b/boxes/ncn-common/variables.pkr.hcl
@@ -69,6 +69,11 @@ variable "artifact_version" {
   default = "none"
 }
 
+variable "kernel_version" {
+  type    = string
+  default = "5.3.18-59.19.1"
+}
+
 variable "create_kis_artifacts_arguments" {
   type = string
   default = "kernel-initrd-only"

--- a/boxes/sles15-base/base.pkr.hcl
+++ b/boxes/sles15-base/base.pkr.hcl
@@ -73,7 +73,7 @@ source "qemu" "sles15-base" {
   ssh_wait_timeout = "${var.ssh_wait_timeout}"
   output_directory = "${var.output_directory}"
   vnc_bind_address = "${var.vnc_bind_address}"
-  vm_name = "${var.image_name}.${var.qemu_format}"
+  vm_name = "${var.image_name}-${var.artifact_version}.${var.qemu_format}"
 }
 
 build {
@@ -86,6 +86,9 @@ build {
   }
 
   provisioner "shell" {
+    environment_vars = [
+      "SLES15_KERNEL_VERSION=${var.kernel_version}"
+    ]
     script = "${path.root}/scripts/kernel.sh"
   }
 

--- a/boxes/sles15-base/scripts/kernel.sh
+++ b/boxes/sles15-base/scripts/kernel.sh
@@ -2,11 +2,7 @@
 
 set -ex
 
-SLES15_KERNEL_VERSION="5.3.18-59.19.1"
-
-KERNEL_PACKAGES=(kernel-default-debuginfo-"$SLES15_KERNEL_VERSION"
-kernel-default-devel-"$SLES15_KERNEL_VERSION"
-kernel-default-debugsource-"$SLES15_KERNEL_VERSION"
+KERNEL_PACKAGES=(kernel-default-devel-"$SLES15_KERNEL_VERSION"
 kernel-default-"$SLES15_KERNEL_VERSION")
 
 zypper --non-interactive remove $(rpm -qa | grep kernel-default)

--- a/boxes/sles15-base/variables.pkr.hcl
+++ b/boxes/sles15-base/variables.pkr.hcl
@@ -40,7 +40,7 @@ variable "source_iso_checksum" {
 
 variable "source_iso_uri" {
   type = string
-  default = "iso/SLE-15-SP3-Full-x86_64-GM-Media1.iso"
+  default = "iso/SLE-15-SP3-Online-x86_64-GM-Media1.iso"
 }
 
 variable "ssh_password" {
@@ -67,6 +67,11 @@ variable "output_directory" {
 variable "artifact_version" {
   type = string
   default = "none"
+}
+
+variable "kernel_version" {
+  type    = string
+  default = "5.3.18-59.19.1"
 }
 
 variable "create_kis_artifacts_arguments" {


### PR DESCRIPTION
#### Summary and Scope

- Fixes the size of cloud images by reducing the size. 
- Switches base build to use Online version of SLES15 ISO. Reducing the size of the download.
- Removes left over code from debugging.
- Converts kernel version to a parameter.
- Adjusts output of base layer to include version string in filename to enable GCP upload locally in addition to build pipeline.

The Packer code splits the install and pinning of the kernel version so that the debug packages are not installed in the base layer, and again not installed for GCP code. 

##### Issue Type
N/A

#### Prerequisites
N/A

#### Idempotency
 
N/A
 
#### Risks and Mitigations
 
N/A
