### PR TITLE
MTL-1587 Overwrite any FS Signature

### DIFF
--- a/boxes/ncn-common/files/scripts/metal/install.sh
+++ b/boxes/ncn-common/files/scripts/metal/install.sh
@@ -16,6 +16,7 @@ breakaway() {
         write_default_route
         clean_bogies
         drop_metal_tcp_ip bond0
+        remove_fs_overwrite
     ) 2>/var/log/cloud-init-metal-breakaway.error
 }
 

--- a/boxes/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/boxes/ncn-common/files/scripts/metal/metal-lib.sh
@@ -35,6 +35,16 @@ trim() {
     printf "%s" "$var"
 }
 
+remove_fs_overwrite() {
+    echo 'note: re-running cloud-init will not wipe any LVMs in /dev/md/AUX; to purge these on a re-run, source the metal-lib and invoke enable_fs_overwrite'
+    find /etc/cloud -name *metalfs.cfg -exec sed -i 's/overwrite: true/overwrite: false/g' {} \; 
+}
+
+enable_fs_overwrite() {
+    echo >2 'warning: re-running cloud-init will now wipe all LVMs in /dev/md/AUX!'
+    find /etc/cloud -name *metalfs.cfg -exec sed -i 's/overwrite: true/overwrite: false/g' {} \; 
+}
+
 install_grub2() {
     local working_path=${1:-/metal/recovery}
     mount -v -L $fslabel $working_path 2>/dev/null || echo 'continuing ...'

--- a/boxes/ncn-node-images/k8s/files/resources/metal/cloud.cfg.d/01_metalfs.cfg
+++ b/boxes/ncn-node-images/k8s/files/resources/metal/cloud.cfg.d/01_metalfs.cfg
@@ -4,3 +4,4 @@ fs_setup:
       filesystem: ext4
       device: /dev/disk/by-id/dm-name-metalvg0-CRAYS3CACHE
       partition: auto
+      overwrite: true

--- a/boxes/ncn-node-images/storage-ceph/files/resources/metal/cloud.cfg.d/01_metalfs.cfg
+++ b/boxes/ncn-node-images/storage-ceph/files/resources/metal/cloud.cfg.d/01_metalfs.cfg
@@ -4,14 +4,17 @@ fs_setup:
       filesystem: ext4
       device: /dev/disk/by-id/dm-name-metalvg0-CEPHETC
       partition: auto
+      overwrite: true
     - label: CEPHVAR
       filesystem: ext4
       device: /dev/disk/by-id/dm-name-metalvg0-CEPHVAR
       partition: auto
+      overwrite: true
     - label: CONTAIN
       filesystem: xfs
       device: /dev/disk/by-id/dm-name-metalvg0-CONTAIN
       partition: auto
+      overwrite: true
 mounts:
     - [ LABEL=CEPHETC, /etc/ceph, auto, "defaults" ]
     - [ LABEL=CEPHVAR, /var/lib/ceph, auto, "defaults" ]


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1587

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

This always purges the linux volumes when cloud-init runs initially,
once cloud-init invokes the runcmd the overwrite will be disabled.

This means to enforce an overwrite thereafter one must source
metal-lib.sh and run enable_fs_overwrite. This is desired because a
simple recall of cloud-init shouldn't purge existing data.

Before this fix, these messages would be observed during cloud-init:
```bash
[   95.631225] cloud-init[3539]: WARNING: ext4 signature detected on /dev/metalvg0/CRAYS3CACHE at offset 1080. Wipe it? [y/n]: [n]
```
After this fix those messages will cease and the FS will be formatted by cloud-init.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
