### PR TITLE
MTL-1587 Fix Helper Function

### DIFF
--- a/boxes/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/boxes/ncn-common/files/scripts/metal/metal-lib.sh
@@ -37,12 +37,12 @@ trim() {
 
 remove_fs_overwrite() {
     echo 'note: re-running cloud-init will not wipe any LVMs in /dev/md/AUX; to purge these on a re-run, source the metal-lib and invoke enable_fs_overwrite'
-    find /etc/cloud -name *metalfs.cfg -exec sed -i 's/overwrite: true/overwrite: false/g' {} \; 
+    find /etc/cloud -name *metalfs.cfg -exec sed -i 's/overwrite:.*/overwrite: false/g' {} \;
 }
 
 enable_fs_overwrite() {
     echo >2 'warning: re-running cloud-init will now wipe all LVMs in /dev/md/AUX!'
-    find /etc/cloud -name *metalfs.cfg -exec sed -i 's/overwrite: true/overwrite: false/g' {} \; 
+    find /etc/cloud -name *metalfs.cfg -exec sed -i 's/overwrite:.*/overwrite: true/g' {} \;
 }
 
 install_grub2() {


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Relates to #144 

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The helper function for enabling the FS overwrite was broken, the code
had been copy-pasted and not meticulously inspected.

Testing:
```bash
ncn-m003:~ # vim /srv/cray/scripts/metal/metal-lib.sh
ncn-m003:~ # source !$
source /srv/cray/scripts/metal/metal-lib.sh
ncn-m003:~ # enable_fs_overwrite
ncn-m003:~ # cat /etc/cloud/cloud.cfg.d/01_metalfs.cfg
#cloud-config
fs_setup:
    - label: CRAYS3CACHE
      filesystem: ext4
      device: /dev/disk/by-id/dm-name-metalvg0-CRAYS3CACHE
      partition: auto
      overwrite: true
ncn-m003:~ # remove_fs_overwrite
note: re-running cloud-init will not wipe any LVMs in /dev/md/AUX; to purge these on a re-run, source the metal-lib and invoke enable_fs_overwrite
ncn-m003:~ # cat /etc/cloud/cloud.cfg.d/01_metalfs.cfg
#cloud-config
fs_setup:
    - label: CRAYS3CACHE
      filesystem: ext4
      device: /dev/disk/by-id/dm-name-metalvg0-CRAYS3CACHE
      partition: auto
      overwrite: false
```

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
