### PR TITLE
CASMISNT-3780: bump kernel version to match DVS/LNET/NETETH

### DIFF
--- a/boxes/sles15-base/variables.pkr.hcl
+++ b/boxes/sles15-base/variables.pkr.hcl
@@ -71,7 +71,7 @@ variable "artifact_version" {
 
 variable "kernel_version" {
   type    = string
-  default = "5.3.18-59.19.1"
+  default = "5.3.18-59.34.1"
 }
 
 variable "create_kis_artifacts_arguments" {


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes CASMINST-3780

##### Issue Type

- RFE Pull Request

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
