### PR TITLE
Latest Pre-Release 0.2.39

### DIFF
--- a/boxes/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/boxes/ncn-common/files/scripts/metal/metal-lib.sh
@@ -37,12 +37,12 @@ trim() {
 
 remove_fs_overwrite() {
     echo 'note: re-running cloud-init will not wipe any LVMs in /dev/md/AUX; to purge these on a re-run, source the metal-lib and invoke enable_fs_overwrite'
-    find /etc/cloud -name *metalfs.cfg -exec sed -i 's/overwrite: true/overwrite: false/g' {} \; 
+    find /etc/cloud -name *metalfs.cfg -exec sed -i 's/overwrite:.*/overwrite: false/g' {} \;
 }
 
 enable_fs_overwrite() {
     echo >2 'warning: re-running cloud-init will now wipe all LVMs in /dev/md/AUX!'
-    find /etc/cloud -name *metalfs.cfg -exec sed -i 's/overwrite: true/overwrite: false/g' {} \; 
+    find /etc/cloud -name *metalfs.cfg -exec sed -i 's/overwrite:.*/overwrite: true/g' {} \;
 }
 
 install_grub2() {

--- a/boxes/sles15-base/variables.pkr.hcl
+++ b/boxes/sles15-base/variables.pkr.hcl
@@ -71,7 +71,7 @@ variable "artifact_version" {
 
 variable "kernel_version" {
   type    = string
-  default = "5.3.18-59.19.1"
+  default = "5.3.18-59.34.1"
 }
 
 variable "create_kis_artifacts_arguments" {


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

Release 0.2.39

Includes the following commit:
```
546ad18 (HEAD -> develop, tag: 0.2.39-1, origin/develop, origin/HEAD, origin/CASMISNT-3780, CASMISNT-3780) CASMISNT-3780: bump kernel version to match DVS/LNET/NETETH
```

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
