### PR TITLE
CASMINST-3800 Fix issue with rgw on clusters greater than 3

### DIFF
--- a/boxes/ncn-node-images/storage-ceph/files/scripts/metal/generate_haproxy_cfg.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/metal/generate_haproxy_cfg.sh
@@ -51,7 +51,7 @@ backend rgw-backend
     balance static-rr
     option httpchk GET /"
 
-for host in $(ceph orch ls rgw -f json-pretty|jq -r '.[].placement.hosts|map(.)|join(" ")')
+for host in $(ceph --name client.ro orch ls rgw -f json-pretty|jq -r '.[].placement.hosts|map(.)|join(" ")')
 do
  ip=$(get_ip_from_metadata $host.nmn)
  echo "        server server-$host-rgw0 $ip:8080 check weight 100"

--- a/boxes/ncn-node-images/storage-ceph/files/scripts/metal/lib-1.5.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/metal/lib-1.5.sh
@@ -264,7 +264,7 @@ function init() {
    echo "Setting cephfs allow_standby_replay true"
    ceph fs set cephfs allow_standby_replay true
 
-   ceph orch apply rgw site1 zone1 --placement="3 $(ceph node ls osd|jq -r '.|keys|join(" ")')" --port=8080
+   ceph orch apply rgw site1 zone1 --placement="$num_storage_nodes $(ceph node ls osd|jq -r '.|keys|join(" ")')" --port=8080
 
    echo "Sleeping for 30 seconds to let rgw get going before checking health"
    sleep 30
@@ -281,7 +281,7 @@ function init() {
   ceph config generate-minimal-conf > /etc/ceph/ceph_conf_min
   cp /etc/ceph/ceph_conf_min /etc/ceph/ceph.conf
 
-  for host in $(ceph node ls| jq -r '.mon|keys[]'); do
+  for host in $(ceph node ls| jq -r '.osd|keys[]'); do
     scp /etc/ceph/* $host:/etc/ceph
   done
 

--- a/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-kubernetes_version="1.18.6-0"
+kubernetes_version="1.20.13-0"
 ceph_version='15.2.12.83+g528da226523-3.25.1'
 ansible_version='2.9.21'
 mkdir -p /etc/kubernetes


### PR DESCRIPTION
#### Summary and Scope

There is an issue where the haproxy.cfg did not get generated due to
not calling the read-only ceph key on nodes that are nogt monitors.

This is also fixing an issue of missing minimal ceph.conf on nodes that are
not mons.

- Fixes CASMINST-3800

##### Issue Type

- Bugfix Pull Request

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency

 This is only run during fresh install
 
#### Risks and Mitigations
 
not having this will cause some inconsistency w/ haproxy on ceph cluster greater than 3
