### PR TITLE
Latest Prerelease 0.2.41

### DIFF
--- a/boxes/ncn-common/files/resources/common/cloud.cfg
+++ b/boxes/ncn-common/files/resources/common/cloud.cfg
@@ -35,3 +35,4 @@ system_info:
         ssh_svcname: sshd
 manage_etc_hosts: template
 manage_resolv_conf: true
+disable_network_activation: true

--- a/boxes/ncn-common/files/resources/common/cloud/templates/cloud-init-network.tmpl
+++ b/boxes/ncn-common/files/resources/common/cloud/templates/cloud-init-network.tmpl
@@ -16,7 +16,8 @@ network:
       parameters:
         mode: 802.3ad
         mii-monitor-interval: 100
-        lacp-rate: fast
+        lacp-rate: slow
+        ad-select: bandwidth
         transmit-hash-policy: layer2+3
   vlans:
   {% for name, network in ds.meta_data.ipam.items() if network.vlanid != 0 %}

--- a/boxes/ncn-node-images/storage-ceph/files/scripts/metal/generate_haproxy_cfg.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/metal/generate_haproxy_cfg.sh
@@ -51,7 +51,7 @@ backend rgw-backend
     balance static-rr
     option httpchk GET /"
 
-for host in $(ceph orch ls rgw -f json-pretty|jq -r '.[].placement.hosts|map(.)|join(" ")')
+for host in $(ceph --name client.ro orch ls rgw -f json-pretty|jq -r '.[].placement.hosts|map(.)|join(" ")')
 do
  ip=$(get_ip_from_metadata $host.nmn)
  echo "        server server-$host-rgw0 $ip:8080 check weight 100"

--- a/boxes/ncn-node-images/storage-ceph/files/scripts/metal/lib-1.5.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/metal/lib-1.5.sh
@@ -264,7 +264,7 @@ function init() {
    echo "Setting cephfs allow_standby_replay true"
    ceph fs set cephfs allow_standby_replay true
 
-   ceph orch apply rgw site1 zone1 --placement="3 $(ceph node ls osd|jq -r '.|keys|join(" ")')" --port=8080
+   ceph orch apply rgw site1 zone1 --placement="$num_storage_nodes $(ceph node ls osd|jq -r '.|keys|join(" ")')" --port=8080
 
    echo "Sleeping for 30 seconds to let rgw get going before checking health"
    sleep 30
@@ -281,7 +281,7 @@ function init() {
   ceph config generate-minimal-conf > /etc/ceph/ceph_conf_min
   cp /etc/ceph/ceph_conf_min /etc/ceph/ceph.conf
 
-  for host in $(ceph node ls| jq -r '.mon|keys[]'); do
+  for host in $(ceph node ls| jq -r '.osd|keys[]'); do
     scp /etc/ceph/* $host:/etc/ceph
   done
 

--- a/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-kubernetes_version="1.18.6-0"
+kubernetes_version="1.20.13-0"
 ceph_version='15.2.12.83+g528da226523-3.25.1'
 ansible_version='2.9.21'
 mkdir -p /etc/kubernetes


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes CASMINST-3800, CASMINST-3801

Includes the following commits:
```
bf3e264 (HEAD -> develop, tag: 0.2.41-2, origin/develop, origin/HEAD, origin/CASMTRIAGE-2793-redux, CASMTRIAGE-2793-redux) CASMTRIAGE-2793: Disable Network Activation
3ba6ba9 (tag: 0.2.41-1, origin/CASMINST-3800) Including k8s client version bump
54a9edf CASMINST-3800 Fix issue with rgw on clusters greater than 3
```

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request


<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (redbull smoke test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 