### PR TITLE
CASMINST-3803 Validate node image component versions against Nexus

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -217,7 +217,22 @@ pipeline {
                                 def arguments = "-only=qemu.kubernetes -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
                                 publishCsmImages.build(arguments, 'boxes/ncn-node-images/')
                                 publishCsmImages.prepareArtifacts("${ARTIFACTS_DIRECTORY_K8S}", env.VERSION)
-                                def props = "csm.repo.url=${params.csmRpmRepo};csm.repo.branch=${params.csmRpmBranch};build.number=${VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source}"
+                                // List versions of k8s image components as artifact props - use it for csm manifest validation
+                                def kubernetesVersions = readJSON(text: sh(returnStdout: true, script: '''
+                                    source ${WORKSPACE}/boxes/ncn-node-images/k8s/files/resources/common/vars.sh >&2
+                                    echo $(cat <<-EOF
+                                        {
+                                            "KUBERNETES_VERSION": "v${KUBERNETES_PULL_VERSION}",
+                                            "WEAVE_VERSION": "${WEAVE_VERSION}",
+                                            "MULTUS_VERSION": "${MULTUS_VERSION}",
+                                            "VELERO_VERSION": "${VELERO_VERSION}",
+                                            "ETCD_VERSION": "${ETCD_VERSION}",
+                                            "COREDNS_VERSION": "${COREDNS_VERSION}"
+                                        }
+                                    EOF
+                                    )
+                                '''.stripIndent())).collect{k, v -> "csm.versions.${k}=${v}"}.join(";")
+                                def props = "csm.repo.url=${params.csmRpmRepo};csm.repo.branch=${params.csmRpmBranch};build.number=${VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source};${kubernetesVersions}"
                                 publishCsmImages(pattern: ARTIFACTS_DIRECTORY_K8S, imageName: 'kubernetes', version: env.VERSION, props: props)
                             }
                         }


### PR DESCRIPTION
#### Summary and Scope

- Fixes CASMINST-3803
- Relates to CASMINST-3799
- used by https://github.com/Cray-HPE/csm/pull/369

##### Issue Type

- RFE Pull Request

Kubernetes node image come pre-populated with Kubernetes (and some supplementary) container images. Sometimes during install/upgrade, these images need to be re-downloaded from Nexus. For this purpose, Nexus should also be populated with the same versions of images. This change adds a validation step to `assets.sh` script, which ensures that same version are being shipped with node image and installed in Nexus. To perform validation, we need to expose container image versions as node image artifact properties.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
 
#### Idempotency
 
No testing required at node-image-builder side - there's no change in node image itself. Only item properties in Artifactory are getting changed (new properties added). Validation step in `assets.sh` script in `csm` repo is working with old and new node images. If node image does not expose versions of components it contains, validtaion is just not performed.
 
#### Risks and Mitigations
 
Risk is minimal as there's no node image change.
