### PR TITLE
CASMINST-3669: check sp2 repo to determine Nexus health

### DIFF
--- a/boxes/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/boxes/ncn-common/files/scripts/metal/metal-lib.sh
@@ -447,8 +447,12 @@ function paginate() {
 function install_csm_rpms() {
 
     # Verify nexus is available.  It's expected to *not* be available during initial install of the NCNs.
-    if ! curl -sSf https://packages.local/service/rest/v1/components?repository=csm-sle-15sp3 >& /dev/null; then
-        echo "unable to contact nexus, bailing"
+    if ! curl -sSf https://packages.local/service/rest/v1/components?repository=csm-sle-15sp2 >& /dev/null; then
+        echo "***"
+        echo "WARNING: Unable to contact Nexus. This is expected if Nexus is unhealthy or not deployed"
+        echo "         (e.g. during initial NCN deployment). One or more of the following RPMs may not be"
+        echo "         up to date and/or not installed: goss-servers, csm-testing, platform-utils"
+        echo "***"
         return 0
     fi
 


### PR DESCRIPTION
#### Summary and Scope

At some point in the CSM 1.2 development timeline an SP3 repo was
configured in Nexus.  This appears to no longer be the case.  And
since the RPMs we're installing still live in a repo with sp2 in
the name, check for the existence of the sp2 repo in order to
determine Nexus health.

While we're here, adjust the warning message to be more helpful
in the event Nexus is deemed unhealthy.

<!--- Pick one below and delete the rest -->

- Fixes CASMINST-3669

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (Drax)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
