### PR TITLE
CASMINST-3825 - Fix a timing issue with ro ceph keyring creation

### DIFF
--- a/boxes/ncn-node-images/storage-ceph/files/scripts/common/storage-ceph-cloudinit.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/common/storage-ceph-cloudinit.sh
@@ -73,8 +73,13 @@ fi
 enable_ceph_prometheus
 
 # Make ceph read-only client for monitoring
-ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
-ceph auth import -i /etc/ceph/ceph.client.ro.keyring
+
+if ! ceph auth get client.ro > /dev/null 2>&1
+then
+  ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
+  ceph auth import -i /etc/ceph/ceph.client.ro.keyring
+fi
+
 echo "Distributing the client.ro keyring"
 for node in $(ceph orch host ls --format=json|jq -r '.[].hostname'); do scp /etc/ceph/ceph.client.ro.keyring $node:/etc/ceph/ceph.client.ro.keyring; done
 

--- a/boxes/ncn-node-images/storage-ceph/files/scripts/metal/lib-1.5.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/metal/lib-1.5.sh
@@ -271,6 +271,10 @@ function init() {
    wait_for_health_ok
 
   fi
+
+  ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
+  ceph auth import -i /etc/ceph/ceph.client.ro.keyring
+
   . /etc/ansible/boto3_ansible/bin/activate
   . /srv/cray/scripts/common/fix_ansible_inv.sh
   fix_inventory


### PR DESCRIPTION
#### Summary and Scope

This will create the client.ro keyring prior to the ansible run on metal
installs, and will conditionally create it if it doesn't exist in the main
storage cloud-init to cover non-metal installs

- Fixes # CASMINST-3825

##### Issue Type

- Bugfix Pull Request

See summary

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
n/a
 
#### Risks and Mitigations
 
n/a
