### PR TITLE
CASMINST-1850 addition of bucket and user for config-data folder on ceph via s3fs

### DIFF
--- a/boxes/ncn-node-images/k8s/files/scripts/metal/lib.sh
+++ b/boxes/ncn-node-images/k8s/files/scripts/metal/lib.sh
@@ -190,7 +190,7 @@ function configure-s3fs() {
     #
     echo "0 */2 * * * root /usr/bin/prune-s3fs-cache.sh admin-tools ${s3fs_cache_dir} 5368709120" > /etc/cron.d/prune-s3fs-admin-tools-cache
 
-    configure-s3fs-directory config-data config-data /var/lib/admin-tools ${s3fs_opts}
+    configure-s3fs-directory config-data config-data /var/opt/cray/config-data ${s3fs_opts}
     #
     # Caching and cache pruning not needed for config-data folder
     #

--- a/boxes/ncn-node-images/k8s/files/scripts/metal/lib.sh
+++ b/boxes/ncn-node-images/k8s/files/scripts/metal/lib.sh
@@ -190,6 +190,10 @@ function configure-s3fs() {
     #
     echo "0 */2 * * * root /usr/bin/prune-s3fs-cache.sh admin-tools ${s3fs_cache_dir} 5368709120" > /etc/cron.d/prune-s3fs-admin-tools-cache
 
+    configure-s3fs-directory config-data config-data /var/lib/admin-tools ${s3fs_opts}
+    #
+    # Caching and cache pruning not needed for config-data folder
+    #
   else
     configure-s3fs-directory ims boot-images /var/lib/cps-local/boot-images ${s3fs_cache_dir} ${s3fs_opts}
     #

--- a/boxes/ncn-node-images/storage-ceph/files/resources/common/ansible/ceph-rgw-users/roles/ceph-rgw-users/defaults/main.yml
+++ b/boxes/ncn-node-images/storage-ceph/files/resources/common/ansible/ceph-rgw-users/roles/ceph-rgw-users/defaults/main.yml
@@ -28,6 +28,7 @@ cray_velero_rgw_user: "{{ sls_rgw_user |default('VELERO') }}"
 cray_sma_rgw_user: "{{ sma_rgw_user |default('SMA') }}"
 cray_install_artifacts_rgw_user: "{{ artifacts_rgw_user |default('Artifacts') }}"
 cray_postgres_backup_rgw_user: "{{ postgres_backup_rgw_user |default('Postgres-Backup') }}"
+cray_config_data_rgw_user: "{{ config_data_rgw_user |default('Config-Data') }}"
 
 cray_rgw_int_endpoint_url: 'http://ncn-s001:8080'
 cray_rgw_ext_endpoint_url: "http://s3.{{ shasta_domain }}:8080"
@@ -210,6 +211,14 @@ ceph_rgw_users:
     policy_action: "\"s3:*\""
     policy_resource: "\"arn:aws:s3:::postgres-backup\",\"arn:aws:s3:::postgres-backup/*\""
 
+  - user_name: "{{ cray_config_data_rgw_user }}"
+    user_display_name: "CSM config data user"
+    role_name: "{{ cray_config_data_rgw_user }}"
+    role_arn: "arn:aws:iam:::user/{{ cray_config_data_rgw_user }}"
+    policy_name: "{{ cray_config_data_rgw_user }}_Policy"
+    policy_action: "\"s3:*\""
+    policy_resource: "\"arn:aws:s3:::config-data\",\"arn:aws:s3:::config-data/*\""
+
 ceph_rgw_buckets:
   - bucket_name: sat
     bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_sat_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::sat\",\"arn:aws:s3:::sat/*\"]}]}"
@@ -266,3 +275,7 @@ ceph_rgw_buckets:
 
   - bucket_name: postgres-backup
     bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_postgres_backup_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::postgres-backup\",\"arn:aws:s3:::postgres-backup/*\"]}]}"
+
+  - bucket_name: config-data
+    bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_config_data_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::config-data\",\"arn:aws:s3:::config-data/*\"]}]}"
+


### PR DESCRIPTION
This change includes a new ceph-rgw-users/defaults/main and new k8s/files/scripts/metal/lib.sh that includes new lines to create and mount a new config-data bucket at k8s masters.

#### Summary and Scope

- Relates to https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-1850

##### Issue Type

New automation to backup config, prep and other data from PIT node before the m001 switch, and store the data in ceph and make it accessible from a new mount point on each kube master.

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
Testing the ansible automation in surtur to verify users and buckets created successfully.
 
#### Risks and Mitigations
 
If backup operation fails, the pit data files stored in prep won't be backed up. Made mention of this in documentation. If radosgw s3 user and bucket creation fail, the bucket and user will not be created and any CRUD operations in documentation to backup prep data would fail. 