### PR TITLE
Release latest prerelease 0.2.43

### DIFF
--- a/boxes/ncn-node-images/storage-ceph/files/scripts/common/pre-load-images.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/common/pre-load-images.sh
@@ -14,7 +14,6 @@ podman image load registry.local/ceph/ceph:v15.2.8 -i /srv/cray/resources/common
 podman image load registry.local/ceph/ceph:v15.2.12 -i /srv/cray/resources/common/images/ceph_v15.2.12.tar
 podman image load registry.local/ceph/ceph-grafana:6.6.2 -i /srv/cray/resources/common/images/ceph-grafana_6.6.2.tar
 podman image load registry.local/ceph/ceph-grafana:6.7.4 -i /srv/cray/resources/common/images/ceph-grafana_6.7.4.tar
-podman image load registry.local/prometheus/prometheus:v2.18.1 -i /srv/cray/resources/common/images/prometheus_v2.18.1.tar
 podman image load registry.local/quay.io/prometheus/prometheus:v2.18.1 -i /srv/cray/resources/common/images/prometheus_v2.18.1.tar
 podman image load registry.local/quay.io/prometheus/alertmanager:v0.20.0 -i /srv/cray/resources/common/images/alertmanager_v0.20.0.tar
 podman image load registry.local/quay.io/prometheus/alertmanager:v0.21.0 -i /srv/cray/resources/common/images/alertmanager_v0.21.0.tar

--- a/boxes/ncn-node-images/storage-ceph/files/scripts/common/pre-load-images.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/common/pre-load-images.sh
@@ -15,6 +15,7 @@ podman image load registry.local/ceph/ceph:v15.2.12 -i /srv/cray/resources/commo
 podman image load registry.local/ceph/ceph-grafana:6.6.2 -i /srv/cray/resources/common/images/ceph-grafana_6.6.2.tar
 podman image load registry.local/ceph/ceph-grafana:6.7.4 -i /srv/cray/resources/common/images/ceph-grafana_6.7.4.tar
 podman image load registry.local/prometheus/prometheus:v2.18.1 -i /srv/cray/resources/common/images/prometheus_v2.18.1.tar
+podman image load registry.local/quay.io/prometheus/prometheus:v2.18.1 -i /srv/cray/resources/common/images/prometheus_v2.18.1.tar
 podman image load registry.local/quay.io/prometheus/alertmanager:v0.20.0 -i /srv/cray/resources/common/images/alertmanager_v0.20.0.tar
 podman image load registry.local/quay.io/prometheus/alertmanager:v0.21.0 -i /srv/cray/resources/common/images/alertmanager_v0.21.0.tar
 podman image load registry.local/quay.io/prometheus/node-exporter:v0.18.1 -i /srv/cray/resources/common/images/node-exporter_v0.18.1.tar

--- a/boxes/ncn-node-images/storage-ceph/files/scripts/common/storage-ceph-cloudinit.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/common/storage-ceph-cloudinit.sh
@@ -73,8 +73,13 @@ fi
 enable_ceph_prometheus
 
 # Make ceph read-only client for monitoring
-ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
-ceph auth import -i /etc/ceph/ceph.client.ro.keyring
+
+if ! ceph auth get client.ro > /dev/null 2>&1
+then
+  ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
+  ceph auth import -i /etc/ceph/ceph.client.ro.keyring
+fi
+
 echo "Distributing the client.ro keyring"
 for node in $(ceph orch host ls --format=json|jq -r '.[].hostname'); do scp /etc/ceph/ceph.client.ro.keyring $node:/etc/ceph/ceph.client.ro.keyring; done
 

--- a/boxes/ncn-node-images/storage-ceph/files/scripts/metal/lib-1.5.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/metal/lib-1.5.sh
@@ -271,6 +271,10 @@ function init() {
    wait_for_health_ok
 
   fi
+
+  ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
+  ceph auth import -i /etc/ceph/ceph.client.ro.keyring
+
   . /etc/ansible/boto3_ansible/bin/activate
   . /srv/cray/scripts/common/fix_ansible_inv.sh
   fix_inventory


### PR DESCRIPTION
#### Summary and Scope

Release 0.2.43.  Contains the following commits:
```
55f0fed (HEAD -> develop, tag: 0.2.43-1, origin/develop, origin/HEAD, origin/CASMINST-3827, CASMINST-3827) CASMINST-3827 - fix container image path for ceph's prometheus
e859c65 CASMINST-3827 - Fix tagging on ceph prometheus image
721149d CASMINST-3825 - Fix a timing issue with ro ceph keyring creation
```

- Fixes CASMINST-3827, CASMINST-3825


##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request


<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (redbull)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 