### PR TITLE
Add logic to terminate multus pods if they get stuck terminating

### DIFF
--- a/boxes/ncn-node-images/k8s/files/scripts/common/apply-networking-manifests.sh
+++ b/boxes/ncn-node-images/k8s/files/scripts/common/apply-networking-manifests.sh
@@ -14,15 +14,41 @@ function apply_weave_manifest () {
   kubectl rollout status daemonset weave-net -n kube-system
 }
 
+function wait_for_multus_rollout() {
+  echo "Wait for Multus Daemonset rollout to complete..."
+  #
+  # Give the K8S ten minutes to roll through the pods
+  #
+  kubectl rollout status daemonset --timeout='10m' kube-multus-ds-amd64 -n kube-system > /dev/null 2>&1
+  if [ "$?" -eq 0 ]; then
+    echo "Multus Daemonset rollout is complete."
+    return
+  fi
+  #
+  # Rollout not done after ten minutes, let's terminate pods that are stuck
+  #
+  while true; do
+    kubectl rollout status daemonset --timeout='1m' kube-multus-ds-amd64 -n kube-system > /dev/null 2>&1
+    if [ "$?" -ne 0 ]; then
+      read -r pod_name pod_state < <(kubectl get pod -n kube-system -l 'app=multus' | grep Terminating | head -1l | awk '{print $1 " " $3}')
+      if [ "$pod_state" == "Terminating" ]; then
+        echo "Deleting $pod_name so rollout will continue..."
+        kubectl delete pod -n kube-system $pod_name --force --grace-period=0 > /dev/null 2>&1
+      fi
+    else
+      echo "Multus Daemonset rollout is complete."
+      break
+    fi
+  done
+}
+
 function apply_multus_manifest () {
   . /srv/cray/resources/common/vars.sh
 
   echo "Installing Multus DaemonSet"
   envsubst < /srv/cray/resources/common/multus/multus-daemonset.yml > /etc/cray/kubernetes/multus-daemonset.yml
   kubectl apply -f /etc/cray/kubernetes/multus-daemonset.yml
-
-  echo "Wait for initial Multus Daemonset pod to be ready..."
-  kubectl rollout status daemonset kube-multus-ds-amd64 -n kube-system
+  wait_for_multus_rollout
 }
 
 apply_weave_manifest


### PR DESCRIPTION
#### Summary and Scope

- Fixes https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3838

##### Issue Type

- Bugfix Pull Request

Multus pods sometimes need a force terminate when rolling out a change, this change deletes them if they don't terminate cleanly.

#### Prerequisites

- [x] I tested this on craystack (if yes, please include results or a description of the test)

From cloud-init:
```
Wait for Multus Daemonset rollout to complete...
Multus Daemonset rollout is complete.
```
 
#### Idempotency
 
Ran the script during development multiple times
 
#### Risks and Mitigations
 
Low risk
