### PR TITLE
CASMINST-3834: Reorganize Jenkinsfile to improve building efficiency.

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -107,224 +107,223 @@ pipeline {
 				}
 			}
         }
-        // Always build.
-        stage("Upload Base Images") {
-            parallel {
-                stage('Upload Base to Artifactory') {
-                    when {
-                        expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-                        expression { params.rebuildBaseImage || (params.rebuildBaseImage && ! params.rebuildCommonImage) }
-                    }
-                    steps {
-                        script {
-                            def props = "csm.repo.url=${params.csmRpmRepo};csm.repo.branch=${params.csmRpmBranch};build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${ISO_URL}"
-                            publishCsmImages(pattern: ARTIFACTS_DIRECTORY_BASE, imageName: 'sles15-base', version: env.VERSION, props: props)
-                        }
-                    }
-                }
-                stage('Upload Base to Google') {
-                    when {
-                        expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-                        expression { params.rebuildBaseImage || (params.rebuildBaseImage && ! params.rebuildCommonImage) }
-                        expression { params.buildGoogle }
-                    }
-                    steps {
-                        withCredentials([
-                            file(credentialsId: 'google-image-manager', variable: 'GOOGLE_CLOUD_SA_KEY')
-                        ]) {
-                            script {
-                                sh "./scripts/google/import.sh"
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        // Always build.
-        stage("Build common") {
-            parallel {
-                stage('QEMU Common') {
-                    when {
-                        expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-                        expression { params.rebuildCommonImage }
-                    }
-                    steps {
-                        withCredentials([
-                            string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
-                            usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
-                        ]) {
-                            script {
-                                // If we didn't rebuild in this build, then always grab latest stable base.
-                                def source = params.rebuildBaseImage ? "${ARTIFACTS_DIRECTORY_BASE}/sles15-base-${VERSION}.qcow2" : "${STABLE_BASE}/sles15-base/[RELEASE]/sles15-base-[RELEASE].qcow2"
-                                def arguments = "-only=qemu.ncn-common -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
-                                publishCsmImages.build(arguments, 'boxes/ncn-common/')
-                                publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_COMMON, VERSION)
-                                def props = "csm.repo.url=${params.csmRpmRepo};csm.repo.branch=${params.csmRpmBranch};build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source}"
-                                publishCsmImages(pattern: ARTIFACTS_DIRECTORY_COMMON, imageName: 'ncn-common', version: env.VERSION, props: props)
-                            }
-                        }
-                    }
-                }
-                stage('GCP Common') {
-                    when {
-                        expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-                        expression { params.rebuildCommonImage }
-                        expression { params.buildGoogle }
-                    }
-                    steps {
-                        withCredentials([
-                            string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
-                            usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN'),
-                            file(credentialsId: 'google-image-manager', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
-                            file(credentialsId: 'google-image-manager', variable: 'GOOGLE_CLOUD_SA_KEY')
-                        ]) {
-                            script {
-                                // Did we build base? If YES, just use the RC image we built. If NO then use the latest non-RC
-                                def googleSourceArtifact = params.rebuildBaseImage ? "vshasta-sles15-base-${VERSION}" : ""
-                                if (googleSourceArtifact == "") {
-                                    googleSourceArtifact = getGoogleCloudSourceArtifact(
-                                        googleCloudSaKey: env.GOOGLE_CLOUD_SA_KEY,
-                                        googleCloudProject: params.sourceProjectId,
-                                        googleCloudFamily: 'vshasta-sles15-base',
-                                        fullUrl: false
-                                    )
-                                }
+        stage("Upload base and build common") {
+        	parallel {
+        		stage("Build with QEMU") {
+        			stages {
+						stage('Upload Base to Artifactory') {
+							when {
+								expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
+								expression { params.rebuildBaseImage || (params.rebuildBaseImage && ! params.rebuildCommonImage) }
+							}
+							steps {
+								script {
+									def props = "csm.repo.url=${params.csmRpmRepo};csm.repo.branch=${params.csmRpmBranch};build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${ISO_URL}"
+									publishCsmImages(pattern: ARTIFACTS_DIRECTORY_BASE, imageName: 'sles15-base', version: env.VERSION, props: props)
+								}
+							}
+						}
+						stage('QEMU Common') {
+							when {
+								expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
+								expression { params.rebuildCommonImage }
+							}
+							steps {
+								withCredentials([
+									string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
+									usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
+								]) {
+									script {
+										// If we didn't rebuild in this build, then always grab latest stable base.
+										def source = params.rebuildBaseImage ? "${ARTIFACTS_DIRECTORY_BASE}/sles15-base-${VERSION}.qcow2" : "${STABLE_BASE}/sles15-base/[RELEASE]/sles15-base-[RELEASE].qcow2"
+										def arguments = "-only=qemu.ncn-common -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
+										publishCsmImages.build(arguments, 'boxes/ncn-common/')
+										publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_COMMON, VERSION)
+										def props = "csm.repo.url=${params.csmRpmRepo};csm.repo.branch=${params.csmRpmBranch};build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source}"
+										publishCsmImages(pattern: ARTIFACTS_DIRECTORY_COMMON, imageName: 'ncn-common', version: env.VERSION, props: props)
+									}
+								}
+							}
+						}
+        			}
+        		}
+        		stage("Build with GCP") {
+        			stages {
+        				stage('Upload Base to Google') {
+							when {
+								expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
+								expression { params.rebuildBaseImage || (params.rebuildBaseImage && ! params.rebuildCommonImage) }
+								expression { params.buildGoogle }
+							}
+							steps {
+								withCredentials([
+									file(credentialsId: 'google-image-manager', variable: 'GOOGLE_CLOUD_SA_KEY')
+								]) {
+									script {
+										sh "./scripts/google/import.sh"
+									}
+								}
+							}
+						}
+						stage('GCP Common') {
+							when {
+								expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
+								expression { params.rebuildCommonImage }
+								expression { params.buildGoogle }
+							}
+							steps {
+								withCredentials([
+									string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
+									usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN'),
+									file(credentialsId: 'google-image-manager', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
+									file(credentialsId: 'google-image-manager', variable: 'GOOGLE_CLOUD_SA_KEY')
+								]) {
+									script {
+										// Did we build base? If YES, just use the RC image we built. If NO then use the latest non-RC
+										def googleSourceArtifact = params.rebuildBaseImage ? "vshasta-sles15-base-${VERSION}" : ""
+										if (googleSourceArtifact == "") {
+											googleSourceArtifact = getGoogleCloudSourceArtifact(
+												googleCloudSaKey: env.GOOGLE_CLOUD_SA_KEY,
+												googleCloudProject: params.sourceProjectId,
+												googleCloudFamily: 'vshasta-sles15-base',
+												fullUrl: false
+											)
+										}
 
-                                def googleArguments = "-only=googlecompute.ncn-common -var 'google_source_image_name=${googleSourceArtifact}' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'artifact_version=${VERSION}'"
-                                publishCsmImages.build(googleArguments, 'boxes/ncn-common/')
-                            }
-                        }
-                    }
+										def googleArguments = "-only=googlecompute.ncn-common -var 'google_source_image_name=${googleSourceArtifact}' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'artifact_version=${VERSION}'"
+										publishCsmImages.build(googleArguments, 'boxes/ncn-common/')
+									}
+								}
+							}
+						}
+        			}
+        		}
+        	}
+        }
+        stage("Build Kubernetes and Storage-Ceph") {
+        	parallel {
+				stage('QEMU Kubernetes Image') {
+					when {
+						expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
+					}
+
+					steps {
+						withCredentials([
+							string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
+							usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
+						]) {
+							script {
+								def source = params.rebuildCommonImage ? "${ARTIFACTS_DIRECTORY_COMMON}/ncn-common-${VERSION}.qcow2" : "${STABLE_BASE}/ncn-common/[RELEASE]/ncn-common-[RELEASE].qcow2"
+								def arguments = "-only=qemu.kubernetes -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
+								publishCsmImages.build(arguments, 'boxes/ncn-node-images/')
+								publishCsmImages.prepareArtifacts("${ARTIFACTS_DIRECTORY_K8S}", env.VERSION)
+								// List versions of k8s image components as artifact props - use it for csm manifest validation
+								def kubernetesVersions = readJSON(text: sh(returnStdout: true, script: '''
+									source ${WORKSPACE}/boxes/ncn-node-images/k8s/files/resources/common/vars.sh >&2
+									echo $(cat <<-EOF
+										{
+											"KUBERNETES_VERSION": "v${KUBERNETES_PULL_VERSION}",
+											"WEAVE_VERSION": "${WEAVE_VERSION}",
+											"MULTUS_VERSION": "${MULTUS_VERSION}",
+											"VELERO_VERSION": "${VELERO_VERSION}",
+											"ETCD_VERSION": "${ETCD_VERSION}",
+											"COREDNS_VERSION": "${COREDNS_VERSION}"
+										}
+									EOF
+									)
+								'''.stripIndent())).collect{k, v -> "csm.versions.${k}=${v}"}.join(";")
+								def props = "csm.repo.url=${params.csmRpmRepo};csm.repo.branch=${params.csmRpmBranch};build.number=${VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source};${kubernetesVersions}"
+								publishCsmImages(pattern: ARTIFACTS_DIRECTORY_K8S, imageName: 'kubernetes', version: env.VERSION, props: props)
+							}
+						}
+					}
 				}
-            }
+				stage('QEMU Ceph Image') {
+					when {
+						expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
+					}
+					steps {
+						withCredentials([
+							string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
+							usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
+						]) {
+							script {
+								def source = params.rebuildCommonImage ? "${ARTIFACTS_DIRECTORY_COMMON}/ncn-common-${VERSION}.qcow2" : "${STABLE_BASE}/ncn-common/[RELEASE]/ncn-common-[RELEASE].qcow2"
+								def arguments = "-only=qemu.storage-ceph -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
+								publishCsmImages.build(arguments, 'boxes/ncn-node-images/')
+								sh "ls -lhR ${ARTIFACTS_DIRECTORY_CEPH}"
+								publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_CEPH, VERSION)
+								sh "ls -lhR ${ARTIFACTS_DIRECTORY_CEPH}"
+								def props = "csm.repo.url=${params.csmRpmRepo};csm.repo.branch=${params.csmRpmBranch};build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source}"
+								publishCsmImages(pattern: ARTIFACTS_DIRECTORY_CEPH, imageName: 'storage-ceph', version: VERSION, props: props)
+							}
+						}
+					}
+				}
+				stage('GCP Kubernetes Image') {
+					when {
+						expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
+						expression { params.rebuildCommonImage }
+						expression { params.buildGoogle }
+					}
+					steps {
+						withCredentials([
+							string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
+							usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN'),
+							file(credentialsId: 'google-image-manager', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
+							file(credentialsId: 'google-image-manager', variable: 'GOOGLE_CLOUD_SA_KEY')
+						]) {
+							script {
+								// Did we build common? If YES, just use the RC image we built. If NO then use the latest non-RC
+								def googleSourceArtifact = params.rebuildBaseImage ? "vshasta-ncn-common-${VERSION}" : ""
+								if (googleSourceArtifact == "") {
+									googleSourceArtifact = getGoogleCloudSourceArtifact(
+										googleCloudSaKey: env.GOOGLE_CLOUD_SA_KEY,
+										googleCloudProject: params.sourceProjectId,
+										googleCloudFamily: 'vshasta-ncn-common',
+										fullUrl: false
+									)
+								}
+
+								def googleArguments = "-only=googlecompute.kubernetes -var 'google_source_image_name=${googleSourceArtifact}' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'artifact_version=${VERSION}'"
+								publishCsmImages.build(googleArguments, 'boxes/ncn-node-images/')
+							}
+						}
+					}
+				}
+				stage('GCP Ceph Image') {
+					when {
+						expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
+						expression { params.rebuildCommonImage }
+						expression { params.buildGoogle }
+					}
+					steps {
+						withCredentials([
+							string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
+							usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN'),
+							file(credentialsId: 'google-image-manager', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
+							file(credentialsId: 'google-image-manager', variable: 'GOOGLE_CLOUD_SA_KEY')
+						]) {
+							script {
+								// Did we build base? If YES, just use the RC image we build. If NO then use the latest non-RC
+								def googleSourceArtifact = params.rebuildBaseImage ? "vshasta-ncn-common-${VERSION}" : ""
+								if (googleSourceArtifact == "") {
+									googleSourceArtifact = getGoogleCloudSourceArtifact(
+										googleCloudSaKey: env.GOOGLE_CLOUD_SA_KEY,
+										googleCloudProject: params.sourceProjectId,
+										googleCloudFamily: 'vshasta-ncn-common',
+										fullUrl: false
+									)
+								}
+
+								def googleArguments = "-only=googlecompute.storage-ceph -var 'google_source_image_name=${googleSourceArtifact}' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'artifact_version=${VERSION}'"
+								publishCsmImages.build(googleArguments, 'boxes/ncn-node-images/')
+							}
+						}
+					}
+				}
+        	}
         }
-        // Always build.
-        // TODO: Allow building either or in Jenkins.
-        stage("Build images") {
-            parallel {
-                stage('QEMU Kubernetes Image') {
-                    when {
-                        expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-                    }
-
-                    steps {
-                        withCredentials([
-                            string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
-                            usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
-                        ]) {
-                            script {
-                                def source = params.rebuildCommonImage ? "${ARTIFACTS_DIRECTORY_COMMON}/ncn-common-${VERSION}.qcow2" : "${STABLE_BASE}/ncn-common/[RELEASE]/ncn-common-[RELEASE].qcow2"
-                                def arguments = "-only=qemu.kubernetes -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
-                                publishCsmImages.build(arguments, 'boxes/ncn-node-images/')
-                                publishCsmImages.prepareArtifacts("${ARTIFACTS_DIRECTORY_K8S}", env.VERSION)
-                                // List versions of k8s image components as artifact props - use it for csm manifest validation
-                                def kubernetesVersions = readJSON(text: sh(returnStdout: true, script: '''
-                                    source ${WORKSPACE}/boxes/ncn-node-images/k8s/files/resources/common/vars.sh >&2
-                                    echo $(cat <<-EOF
-                                        {
-                                            "KUBERNETES_VERSION": "v${KUBERNETES_PULL_VERSION}",
-                                            "WEAVE_VERSION": "${WEAVE_VERSION}",
-                                            "MULTUS_VERSION": "${MULTUS_VERSION}",
-                                            "VELERO_VERSION": "${VELERO_VERSION}",
-                                            "ETCD_VERSION": "${ETCD_VERSION}",
-                                            "COREDNS_VERSION": "${COREDNS_VERSION}"
-                                        }
-                                    EOF
-                                    )
-                                '''.stripIndent())).collect{k, v -> "csm.versions.${k}=${v}"}.join(";")
-                                def props = "csm.repo.url=${params.csmRpmRepo};csm.repo.branch=${params.csmRpmBranch};build.number=${VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source};${kubernetesVersions}"
-                                publishCsmImages(pattern: ARTIFACTS_DIRECTORY_K8S, imageName: 'kubernetes', version: env.VERSION, props: props)
-                            }
-                        }
-                    }
-                }
-                stage('GCP Kubernetes Image') {
-                    when {
-                        expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-                        expression { params.rebuildCommonImage }
-                        expression { params.buildGoogle }
-                    }
-                    steps {
-                        withCredentials([
-                            string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
-                            usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN'),
-                            file(credentialsId: 'google-image-manager', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
-                            file(credentialsId: 'google-image-manager', variable: 'GOOGLE_CLOUD_SA_KEY')
-                        ]) {
-                            script {
-                                // Did we build common? If YES, just use the RC image we built. If NO then use the latest non-RC
-                                def googleSourceArtifact = params.rebuildBaseImage ? "vshasta-ncn-common-${VERSION}" : ""
-                                if (googleSourceArtifact == "") {
-                                    googleSourceArtifact = getGoogleCloudSourceArtifact(
-                                        googleCloudSaKey: env.GOOGLE_CLOUD_SA_KEY,
-                                        googleCloudProject: params.sourceProjectId,
-                                        googleCloudFamily: 'vshasta-ncn-common',
-                                        fullUrl: false
-                                    )
-                                }
-
-                                def googleArguments = "-only=googlecompute.kubernetes -var 'google_source_image_name=${googleSourceArtifact}' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'artifact_version=${VERSION}'"
-                                publishCsmImages.build(googleArguments, 'boxes/ncn-node-images/')
-                            }
-                        }
-                    }
-                }
-                stage('QEMU Ceph Image') {
-                    when {
-                        expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-                    }
-                    steps {
-                        withCredentials([
-                            string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
-                            usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
-                        ]) {
-                            script {
-                                def source = params.rebuildCommonImage ? "${ARTIFACTS_DIRECTORY_COMMON}/ncn-common-${VERSION}.qcow2" : "${STABLE_BASE}/ncn-common/[RELEASE]/ncn-common-[RELEASE].qcow2"
-                                def arguments = "-only=qemu.storage-ceph -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
-                                publishCsmImages.build(arguments, 'boxes/ncn-node-images/')
-                                sh "ls -lhR ${ARTIFACTS_DIRECTORY_CEPH}"
-                                publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_CEPH, VERSION)
-                                sh "ls -lhR ${ARTIFACTS_DIRECTORY_CEPH}"
-                                def props = "csm.repo.url=${params.csmRpmRepo};csm.repo.branch=${params.csmRpmBranch};build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source}"
-                                publishCsmImages(pattern: ARTIFACTS_DIRECTORY_CEPH, imageName: 'storage-ceph', version: VERSION, props: props)
-                            }
-                        }
-                    }
-                }
-                stage('GCP Ceph Image') {
-                    when {
-                        expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-                        expression { params.rebuildCommonImage }
-                        expression { params.buildGoogle }
-                    }
-                    steps {
-                        withCredentials([
-                            string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
-                            usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN'),
-                            file(credentialsId: 'google-image-manager', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
-                            file(credentialsId: 'google-image-manager', variable: 'GOOGLE_CLOUD_SA_KEY')
-                        ]) {
-                            script {
-                                // Did we build base? If YES, just use the RC image we build. If NO then use the latest non-RC
-                                def googleSourceArtifact = params.rebuildBaseImage ? "vshasta-ncn-common-${VERSION}" : ""
-                                if (googleSourceArtifact == "") {
-                                    googleSourceArtifact = getGoogleCloudSourceArtifact(
-                                        googleCloudSaKey: env.GOOGLE_CLOUD_SA_KEY,
-                                        googleCloudProject: params.sourceProjectId,
-                                        googleCloudFamily: 'vshasta-ncn-common',
-                                        fullUrl: false
-                                    )
-                                }
-
-                                def googleArguments = "-only=googlecompute.storage-ceph -var 'google_source_image_name=${googleSourceArtifact}' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'artifact_version=${VERSION}'"
-                                publishCsmImages.build(googleArguments, 'boxes/ncn-node-images/')
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
         // This should run stand-alone; nothing should build when we release, we're just moving things within artifactory.
         stage('Release') {
             when { tag "*" }

--- a/boxes/ncn-node-images/node-images.pkr.hcl
+++ b/boxes/ncn-node-images/node-images.pkr.hcl
@@ -385,20 +385,29 @@ build {
   provisioner "shell" {
     inline = [
       "bash -c 'goss -g /srv/cray/tests/metal/goss-image-common.yaml validate -f junit | tee /tmp/goss_metal_out.xml'"]
-    except = ["googlecompute.ncn-common"]
+    except = [
+      "googlecompute.kubernetes",
+      "googlecompute.storage-ceph"
+    ]
   }
 
   provisioner "shell" {
     inline = [
       "bash -c 'goss -g /srv/cray/tests/google/goss-image-common.yaml validate -f junit | tee /tmp/goss_google_out.xml'"]
-    only = ["googlecompute.ncn-common"]
+    only = [
+      "googlecompute.kubernetes",
+      "googlecompute.storage-ceph"
+    ]
   }
 
   provisioner "file" {
     direction = "download"
     source = "/tmp/goss_out.xml"
     destination = "${var.output_directory}/${source.name}/test-results.xml"
-    except = ["googlecompute.ncn-common"]
+    except = [
+      "googlecompute.kubernetes",
+      "googlecompute.storage-ceph"
+    ]
   }
 
   provisioner "file" {
@@ -446,7 +455,12 @@ build {
     }
     post-processor "shell-local" {
       inline = [
-        "if cat ${var.output_directory}/${source.name}/test-results.xml | grep '<failure>'; then echo 'Error: goss test failures found! See build output for details'; exit 1; fi"]
+        "if cat ${var.output_directory}/${source.name}/test-results.xml | grep '<failure>'; then echo 'Error: goss test failures found! See build output for details'; exit 1; fi"
+      ]
+      only   = [
+        "qemu.kubernetes",
+        "qemu.storage-ceph"
+      ]
     }
   }
 }


### PR DESCRIPTION
#### Summary and Scope
The original intent of this change was to unblock ncn-common (QEMU) build by allowing the GCP upload to happen in parallel with the QEMU upload and subsequent ncn-common build. When changing the order it was discovered that there is a bug in the code where the GCP storage-ceph build downloaded goss test results locally, resulting in the failure of the QEMU storage-ceph build because the output directory already exists.

The order has been changed and the bug has been resolved. The longest part of the build is still the `e4defrag / > /dev/null 2>&1` which appears to give a bit of a benefit on disk size, but more testing is required.