### PR TITLE
Modify s3fs mount options to include use_xattr

### DIFF
--- a/boxes/ncn-node-images/k8s/files/scripts/metal/lib.sh
+++ b/boxes/ncn-node-images/k8s/files/scripts/metal/lib.sh
@@ -171,9 +171,9 @@ function configure-s3fs() {
   s3fs_cache_dir=/var/lib/s3fs_cache
 
   if [ -d ${s3fs_cache_dir} ]; then
-    s3fs_opts="use_path_request_style,use_cache=${s3fs_cache_dir},check_cache_dir_exist"
+    s3fs_opts="use_path_request_style,use_cache=${s3fs_cache_dir},check_cache_dir_exist,use_xattr"
    else
-    s3fs_opts="use_path_request_style"
+    s3fs_opts="use_path_request_style,use_xattr"
   fi
 
   if [[ "$(hostname)" =~ ^ncn-m ]]; then


### PR DESCRIPTION
#### Summary and Scope

Add use_xaddr s3fs option to enable cpe-slurm installs which require extended attributes.

Tested in craystack:

```
ncn-m002:~ # mount | grep s3fs
s3fs on /var/opt/cray/sdu/collection-mount type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other)
s3fs on /var/lib/admin-tools type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0)
```

```
ncn-m002:~ # cat /etc/fstab
LABEL=SQUASHFS  /  ext4  defaults  0  1
LABEL=CRAYS3CACHE       /var/lib/s3fs_cache     ext4    defaults,nofail,comment=cloudconfig     0       2
sds /var/opt/cray/sdu/collection-mount fuse.s3fs _netdev,allow_other,passwd_file=/root/.sds.s3fs,url=http://ncn-s001:8080,use_path_request_style,use_cache=/tmp,check_cache_dir_exist,use_xattr,uid=2370,gid=2370,umask=0007,allow_other 0 0
admin-tools /var/lib/admin-tools fuse.s3fs _netdev,allow_other,passwd_file=/root/.admin-tools.s3fs,url=http://ncn-s001:8080,use_path_request_style,use_cache=/tmp,check_cache_dir_exist,use_xattr 0 0
```

- Fixes https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-2912

##### Issue Type

- Bugfix Pull Request

Was seeing this on hela before adding the option:

```
error listing extended attributes of "/certificate_authority.crt": operation not supported
```
Adding the option fixed the issue.

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [x] I tested this on craystack (if yes, please include results or a description of the test)
 
#### Idempotency

N/A
 
#### Risks and Mitigations
 
Low
