### PR TITLE
CASMINST-1850 commit that includes new lib.sh and ansible updates for cluster config-data backup

### DIFF
--- a/boxes/ncn-node-images/k8s/files/scripts/metal/lib.sh
+++ b/boxes/ncn-node-images/k8s/files/scripts/metal/lib.sh
@@ -197,7 +197,7 @@ function configure-s3fs() {
     #
     echo "0 */2 * * * root /usr/bin/prune-s3fs-cache.sh admin-tools ${s3fs_cache_dir} 5368709120" > /etc/cron.d/prune-s3fs-admin-tools-cache
 
-    configure-s3fs-directory config-data config-data /var/opt/cray/config-data ${s3fs_opts}
+    configure-s3fs-directory config-data config-data /var/opt/cray/config-data use_path_request_style,use_xattr
     #
     # No cache pruning required for config-data folder as we are not caching this folder
 

--- a/boxes/ncn-node-images/storage-ceph/files/resources/common/ansible/ceph-rgw-users/roles/ceph-rgw-users/defaults/main.yml
+++ b/boxes/ncn-node-images/storage-ceph/files/resources/common/ansible/ceph-rgw-users/roles/ceph-rgw-users/defaults/main.yml
@@ -28,6 +28,7 @@ cray_velero_rgw_user: "{{ sls_rgw_user |default('VELERO') }}"
 cray_sma_rgw_user: "{{ sma_rgw_user |default('SMA') }}"
 cray_install_artifacts_rgw_user: "{{ artifacts_rgw_user |default('Artifacts') }}"
 cray_postgres_backup_rgw_user: "{{ postgres_backup_rgw_user |default('Postgres-Backup') }}"
+cray_config_data_rgw_user: "{{ config_data_rgw_user |default('Config-Data') }}"
 
 cray_rgw_int_endpoint_url: 'http://ncn-s001:8080'
 cray_rgw_ext_endpoint_url: "http://s3.{{ shasta_domain }}:8080"
@@ -210,6 +211,14 @@ ceph_rgw_users:
     policy_action: "\"s3:*\""
     policy_resource: "\"arn:aws:s3:::postgres-backup\",\"arn:aws:s3:::postgres-backup/*\""
 
+  - user_name: "{{ cray_config_data_rgw_user }}"
+    user_display_name: "CSM config data user"
+    role_name: "{{ cray_config_data_rgw_user }}"
+    role_arn: "arn:aws:iam:::user/{{ cray_config_data_rgw_user }}"
+    policy_name: "{{ cray_config_data_rgw_user }}_Policy"
+    policy_action: "\"s3:*\""
+    policy_resource: "\"arn:aws:s3:::config-data\",\"arn:aws:s3:::config-data/*\""
+
 ceph_rgw_buckets:
   - bucket_name: sat
     bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_sat_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::sat\",\"arn:aws:s3:::sat/*\"]}]}"
@@ -266,3 +275,7 @@ ceph_rgw_buckets:
 
   - bucket_name: postgres-backup
     bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_postgres_backup_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::postgres-backup\",\"arn:aws:s3:::postgres-backup/*\"]}]}"
+
+  - bucket_name: config-data
+    bucket_policy: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\": [\"arn:aws:iam:::user/{{ cray_config_data_rgw_user }}\"]},\"Action\":[\"s3:*\"],\"Resource\":[\"arn:aws:s3:::config-data\",\"arn:aws:s3:::config-data/*\"]}]}"
+


### PR DESCRIPTION
CASMINST-1850 commit that includes new lib.sh and ansible updates for cluster config-data backup. The changes to ceph-rgw-users include creating new config-data bucket and Config-Data user.  The changes to lib.sh add some conditional logic to configure and sets up the config-data bucket to mount automatically like the ims boot-images bucket but without s3fs cache functions. We do not want to use the caching function for this data and its not necessary.

Doc changes PR opened in `(coming)`
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes CASMINST-1850

##### Issue Type
- New functionality

<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal metal on surtur
 
#### Idempotency
 
Done for the image build for only master nodes. Because this is part of the image build it would not be manually re-run on nodes. 
#### Risks and Mitigations
 
