### PR TITLE
Reconfigure kube-system docker images to use locally built ones (CASMINST-3799)

### DIFF
--- a/boxes/ncn-node-images/k8s/files/resources/common/kubeadm.yaml
+++ b/boxes/ncn-node-images/k8s/files/resources/common/kubeadm.yaml
@@ -14,7 +14,7 @@ clusterName: kubernetes
 controlPlaneEndpoint: "${CONTROL_PLANE_ENDPOINT}"
 dns:
   type: CoreDNS
-imageRepository: k8s.gcr.io
+imageRepository: "${K8S_IMAGE_REGISTRY}"
 networking:
   dnsDomain: cluster.local
   podSubnet: "${PODS_CIDR}"

--- a/boxes/ncn-node-images/k8s/files/resources/common/multus/multus-daemonset.yml
+++ b/boxes/ncn-node-images/k8s/files/resources/common/multus/multus-daemonset.yml
@@ -122,7 +122,7 @@ spec:
       serviceAccountName: multus
       containers:
       - name: kube-multus
-        image: "docker.io/nfvpe/multus:${MULTUS_VERSION}"
+        image: "${DOCKER_IMAGE_REGISTRY}/nfvpe/multus:${MULTUS_VERSION}"
         command: ["/entrypoint.sh"]
         args:
         - "--cni-conf-dir=/host/etc/cni/net.d"

--- a/boxes/ncn-node-images/k8s/files/resources/common/vars.sh
+++ b/boxes/ncn-node-images/k8s/files/resources/common/vars.sh
@@ -5,15 +5,15 @@
 #
 export KUBERNETES_PULL_PREVIOUS_VERSION="1.19.9"
 export KUBERNETES_PULL_VERSION="1.20.13"
-export KUBE_CONTROLLER_PREVIOUS_IMAGE="cray/kube-controller-manager:v${KUBERNETES_PULL_PREVIOUS_VERSION}"
-export KUBE_CONTROLLER_IMAGE="cray/kube-controller-manager:v${KUBERNETES_PULL_VERSION}"
 export WEAVE_VERSION="2.8.1"
 export WEAVE_PREVIOUS_VERSION="2.8.0"
 export MULTUS_VERSION="v3.7"
+export MULTUS_PREVIOUS_VERSION="v3.1"
 export CONTAINERD_VERSION="1.5.7"
 export HELM_V3_VERSION="3.2.4"
 export VELERO_VERSION="v1.5.2"
 export ETCD_VERSION="v3.5.0"
+export PAUSE_VERSION="3.2"
 #
 # https://github.com/coredns/deployment/blob/master/kubernetes/CoreDNS-k8s_version.md
 #

--- a/boxes/ncn-node-images/k8s/files/resources/common/weave.yaml
+++ b/boxes/ncn-node-images/k8s/files/resources/common/weave.yaml
@@ -179,7 +179,7 @@ items:
                   value: '${WEAVE_MTU}'
                 - name: INIT_CONTAINER
                   value: 'true'
-              image: "docker.io/weaveworks/weave-kube:${WEAVE_VERSION}"
+              image: "${DOCKER_IMAGE_REGISTRY}/weaveworks/weave-kube:${WEAVE_VERSION}"
               readinessProbe:
                 httpGet:
                   host: 127.0.0.1
@@ -208,7 +208,7 @@ items:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: spec.nodeName
-              image: "docker.io/weaveworks/weave-npc:${WEAVE_VERSION}"
+              image: "${DOCKER_IMAGE_REGISTRY}/weaveworks/weave-npc:${WEAVE_VERSION}"
               resources:
                 requests:
                   cpu: 50m
@@ -224,7 +224,7 @@ items:
             - name: weave-init
               command:
                 - /home/weave/init.sh
-              image: "docker.io/weaveworks/weave-kube:${WEAVE_VERSION}"
+              image: "${DOCKER_IMAGE_REGISTRY}/weaveworks/weave-kube:${WEAVE_VERSION}"
               securityContext:
                 privileged: true
               volumeMounts:
@@ -458,7 +458,7 @@ items:
             value: '${WEAVE_MTU}'
           - name: INIT_CONTAINER
             value: 'true'
-          image: "docker.io/weaveworks/weave-kube:${WEAVE_VERSION}"
+          image: "${DOCKER_IMAGE_REGISTRY}/weaveworks/weave-kube:${WEAVE_VERSION}"
           readinessProbe:
             httpGet:
               host: 127.0.0.1
@@ -487,7 +487,7 @@ items:
               fieldRef:
                 apiVersion: v1
                 fieldPath: spec.nodeName
-          image: "docker.io/weaveworks/weave-npc:${WEAVE_VERSION}"
+          image: "${DOCKER_IMAGE_REGISTRY}/weaveworks/weave-npc:${WEAVE_VERSION}"
           resources:
             requests:
               cpu: 50m
@@ -509,7 +509,7 @@ items:
         - name: weave-init
           command:
           - /home/weave/init.sh
-          image: "docker.io/weaveworks/weave-kube:${WEAVE_VERSION}"
+          image: "${DOCKER_IMAGE_REGISTRY}/weaveworks/weave-kube:${WEAVE_VERSION}"
           securityContext:
             privileged: true
           volumeMounts:

--- a/boxes/ncn-node-images/k8s/files/scripts/common/kubernetes-cloudinit.sh
+++ b/boxes/ncn-node-images/k8s/files/scripts/common/kubernetes-cloudinit.sh
@@ -76,7 +76,7 @@ function join() {
     echo "$(cat ${join_script_local}) --apiserver-advertise-address=${K8S_NODE_IP}" > ${join_script_local}
   fi
 
-  chmod +x $join_script_local
+  chmod 0700 $join_script_local
   echo "Attempting to join node to the Kubernetes cluster (will continue to retry if it fails)"
   echo "$(cat $join_script_local)..."
   while ! $join_script_local; do
@@ -117,6 +117,8 @@ fi
 kubeadm token create --print-join-command > /etc/cray/kubernetes/join-command 2>/dev/null
 echo "$(cat /etc/cray/kubernetes/join-command) --control-plane --certificate-key $(cat /etc/cray/kubernetes/certificate-key)" \
   > /etc/cray/kubernetes/join-command-control-plane
+chmod 0700 /etc/cray/kubernetes/join-command
+chmod 0700 /etc/cray/kubernetes/join-command-control-plane
 
 EOF
     chmod +x /srv/cray/scripts/kubernetes/token-certs-refresh.sh

--- a/boxes/ncn-node-images/node-images.pkr.hcl
+++ b/boxes/ncn-node-images/node-images.pkr.hcl
@@ -258,6 +258,11 @@ build {
   }
 
   provisioner "shell" {
+    environment_vars = [
+      "DOCKER_IMAGE_REGISTRY=${var.docker_image_registry}",
+      "K8S_IMAGE_REGISTRY=${var.k8s_image_registry}",
+      "QUAY_IMAGE_REGISTRY=${var.quay_image_registry}"
+    ]
     script = "${path.root}/k8s/provisioners/common/install.sh"
     only = [
       "virtualbox-ovf.kubernetes",

--- a/boxes/ncn-node-images/variables.pkr.hcl
+++ b/boxes/ncn-node-images/variables.pkr.hcl
@@ -13,6 +13,21 @@ variable "disk_size" {
   default = "42000"
 }
 
+variable "docker_image_registry" {
+  type = string
+  default = "artifactory.algol60.net/csm-docker/stable/docker.io"
+}
+
+variable "k8s_image_registry" {
+  type = string
+  default = "artifactory.algol60.net/csm-docker/stable/k8s.gcr.io"
+}
+
+variable "quay_image_registry" {
+  type = string
+  default = "artifactory.algol60.net/csm-docker/stable/quay.io"
+}
+
 variable "headless" {
   type = bool
   default = true


### PR DESCRIPTION
#### Summary and Scope

Use locally built K8S images that match what's being populated in nexus.
Also tighten permissions on K8S join scripts (CASMINST-3860)

- Fixes https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3799
- Fixes https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3860

##### Issue Type

- Bugfix Pull Request

Brings alignment between K8S images in nexus and what's being used at bootstrap time.

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [x] I tested this on craystak (if yes, please include results or a description of the test)

```
ncn-m003:/etc/cray/kubernetes # ls -l join*
-rwx------ 1 root root 318 Jan 26 21:37 join.sh
```

```
ncn-m002:/etc/cray/kubernetes # ls -l join*
-rwx------ 1 root root 177 Jan 26 21:37 join-command
-rwx------ 1 root root 276 Jan 26 21:37 join-command-control-plane
```
```
ncn-m002:~ # kubectl get pods --all-namespaces -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' |sort |uniq
artifactory.algol60.net/csm-docker/stable/docker.io/nfvpe/multus:v3.7
artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns:1.7.0
artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.20.13
artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.20.13
artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.20.13
artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.20.13
```
 
#### Idempotency
 
N/A
 
#### Risks and Mitigations
 
Low
