### PR TITLE
MTL-1610: Alter GCP specific environment configuration and network settings

### DIFF
--- a/boxes/ncn-common/files/scripts/common/build-functions.sh
+++ b/boxes/ncn-common/files/scripts/common/build-functions.sh
@@ -7,7 +7,7 @@
 function pre-pull-internal-images() {
   local image_names="$@"
   for image_name in $image_names; do
-    if [ -f /usr/bin/google_network_daemon ]; then
+    if [ -f /etc/google_system ]; then
       # no need to truly pre-pull in these cases, we'll use runtime
       # auth to pull at that time for Google/Virtual Shasta
       echo "Delaying pre-pull of gcr.io/vshasta-cray/${image_name} to runtime"

--- a/boxes/ncn-common/files/utilities/common/craysys/craysys
+++ b/boxes/ncn-common/files/utilities/common/craysys/craysys
@@ -34,7 +34,7 @@ def setup_cli(): # pragma: NO COVER
     return parser.parse_args()
 
 def get_system_type():
-    if Path('/usr/bin/google_network_daemon').is_file():
+    if Path('/etc/google_system').is_file():
         return 'google'
     else:
         return 'metal'

--- a/boxes/ncn-common/provisioners/google/setup.sh
+++ b/boxes/ncn-common/provisioners/google/setup.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Establish that this is a google system
+touch /etc/google_system
+
 echo "activate public cloud module"
 product=$(sudo SUSEConnect --list-extensions | grep -o "sle-module-public-cloud.*")
 [[ -n "$product" ]] && sudo SUSEConnect -p "$product"

--- a/boxes/ncn-node-images/node-images.pkr.hcl
+++ b/boxes/ncn-node-images/node-images.pkr.hcl
@@ -370,7 +370,16 @@ build {
       "virtualbox-ovf.kubernetes",
       "qemu.kubernetes",
       "virtualbox-ovf.storage-ceph",
-      "qemu.storage-ceph"]
+      "qemu.storage-ceph"
+    ]
+  }
+
+  provisioner "shell" {
+    script = "${path.root}/provisioners/google/cleanup.sh"
+    only = [
+      "googlecompute.kubernetes",
+      "googlecompute.storage-ceph"
+    ]
   }
 
   provisioner "shell" {

--- a/boxes/ncn-node-images/provisioners/google/cleanup.sh
+++ b/boxes/ncn-node-images/provisioners/google/cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo "Modifying DNS to use Google DNS servers..."
+mv /etc/sysconfig/network/config.backup /etc/sysconfig/network/config


### PR DESCRIPTION
#### Summary and Scope
Google no longer uses the `google-network-daemon` for managing network connections. The build process depended on
this service existing for certain portions. In addition to depending on this service, certain DNS changes were made that are not compatible when the end product is put in place. This update removes the dependency and resets networking configurations. 

- Fixes MTL-1610

##### Issue Type

- Bugfix Pull Request

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [] I tested this on metal
- [] I tested this on vshasta
