### PR TITLE
MTL-1606: bump kernel version for CVE-2022-0185

### DIFF
--- a/boxes/ncn-common/variables.pkr.hcl
+++ b/boxes/ncn-common/variables.pkr.hcl
@@ -71,7 +71,7 @@ variable "artifact_version" {
 
 variable "kernel_version" {
   type    = string
-  default = "5.3.18-59.19.1"
+  default = "5.3.18-150300.59.43.1"
 }
 
 variable "create_kis_artifacts_arguments" {

--- a/boxes/sles15-base/variables.pkr.hcl
+++ b/boxes/sles15-base/variables.pkr.hcl
@@ -71,7 +71,7 @@ variable "artifact_version" {
 
 variable "kernel_version" {
   type    = string
-  default = "5.3.18-59.34.1"
+  default = "5.3.18-150300.59.43.1"
 }
 
 variable "create_kis_artifacts_arguments" {


### PR DESCRIPTION
#### Summary and Scope

Bump kernel to 5.3.18-150300.59.43.1 for CVE.

https://www.suse.com/security/cve/CVE-2022-0185.html

<!--- Pick one below and delete the rest -->

- Fixes MTL-1606

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->