### PR TITLE
MTL-1614: be agnostic about whether CRAY entries are bootable

### DIFF
--- a/boxes/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/boxes/ncn-common/files/scripts/metal/metal-lib.sh
@@ -51,7 +51,7 @@ install_grub2() {
 
     # Remove all existing entries; anything with CRAY (lower or uppercase). We
     # only want our boot-loader.
-    for entry in $(efibootmgr | awk -F '*' 'toupper($0) ~ /CRAY/ {print $1}'); do
+    for entry in $(efibootmgr | awk -F '[* ]' 'toupper($0) ~ /CRAY/ {print $1}'); do
          efibootmgr -q -b ${entry:4:8} -B
     done
 


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1614

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

Be agnostic about whether the CRAY entries we're about to delete
are marked as bootable.

Previously (assumes Boot0014 will be Boot0014*):
```
ncn-w002:~ # efibootmgr | grep -i cray
Boot0014  CRAY UEFI OS 1
ncn-w002:~ #

ncn-w002:~ # efibootmgr | awk -F '*' 'toupper($0) ~ /CRAY/ {print $1}'
Boot0014  CRAY UEFI OS 1
ncn-w002:~ #
```
With this commit, awk will use a space or a * as the seperator:
```
ncn-w002:~ # efibootmgr | awk -F '[* ]' 'toupper($0) ~ /CRAY/ {print $1}'
Boot0014
ncn-w002:~ #

ncn-m002:~ # efibootmgr | grep -i cray
Boot000A* CRAY UEFI OS 0
Boot000B* CRAY UEFI OS 1
ncn-m002:~ # efibootmgr | awk -F '[* ]' 'toupper($0) ~ /CRAY/ {print $1}'
Boot000A
Boot000B
ncn-m002:~ #
```
<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on redbull
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
✅ 

