### PR TITLE
CASMINST-3730 Disable FQDN hostnames

### DIFF
--- a/boxes/ncn-common/files/resources/common/cloud.cfg
+++ b/boxes/ncn-common/files/resources/common/cloud.cfg
@@ -36,3 +36,5 @@ system_info:
 manage_etc_hosts: template
 manage_resolv_conf: true
 disable_network_activation: true
+preserve_hostname: false
+prefer_fqdn_over_hostname: false


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes CASMINST-3730

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

This change has been solving the <region>-<hostname> issue for CASMINST-3730. Since adding this into testing with @alexanderkingh on surtur and redbull, we've no longer seen the region hostname appearing during deployments.

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
