### PR TITLE
CASMPET-5328 - Bump ceph upgrade image version

### DIFF
--- a/boxes/ncn-node-images/storage-ceph/files/scripts/common/pre-load-images.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/common/pre-load-images.sh
@@ -11,7 +11,7 @@ echo "Pre-loading local images"
 # done
 
 podman image load registry.local/ceph/ceph:v15.2.8 -i /srv/cray/resources/common/images/ceph_v15.2.8.tar
-podman image load registry.local/ceph/ceph:v15.2.12 -i /srv/cray/resources/common/images/ceph_v15.2.12.tar
+podman image load registry.local/ceph/ceph:v15.2.15 -i /srv/cray/resources/common/images/ceph_v15.2.15.tar
 podman image load registry.local/ceph/ceph-grafana:6.6.2 -i /srv/cray/resources/common/images/ceph-grafana_6.6.2.tar
 podman image load registry.local/ceph/ceph-grafana:6.7.4 -i /srv/cray/resources/common/images/ceph-grafana_6.7.4.tar
 podman image load registry.local/quay.io/prometheus/prometheus:v2.18.1 -i /srv/cray/resources/common/images/prometheus_v2.18.1.tar

--- a/boxes/ncn-node-images/storage-ceph/files/scripts/common/storage-ceph-cloudinit.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/common/storage-ceph-cloudinit.sh
@@ -8,7 +8,7 @@ export KUBECONFIG=/etc/kubernetes/admin.conf
 export CRAYSYS_TYPE=$(craysys type get)
 registry="${1:-registry.local}"
 CSM_RELEASE="${2:-1.5}"
-CEPH_VERS="${3:-15.2.8}"
+CEPH_VERS="${3:-15.2.15}"
 
 . /srv/cray/scripts/${CRAYSYS_TYPE}/lib-${CSM_RELEASE}.sh
 . /srv/cray/scripts/common/wait-for-k8s-worker.sh

--- a/boxes/ncn-node-images/storage-ceph/files/scripts/metal/lib-1.5.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/metal/lib-1.5.sh
@@ -198,7 +198,8 @@ function init() {
    ceph config set mgr mgr/cephadm/container_image_prometheus    "$registry/prometheus/prometheus:v2.18.1"
    ceph config set mgr mgr/cephadm/container_image_alertmanager  "$registry/quay.io/prometheus/alertmanager:v0.21.0"
    ceph config set mgr mgr/cephadm/container_image_node_exporter "$registry/quay.io/prometheus/node-exporter:v1.2.2"
-
+   ceph config set mgr mgr/cephadm/container_image_base "$regsistry/ceph/ceph:$CEPH_VERS"
+   ceph config set glocal container_image "$regsistry/ceph/ceph:$CEPH_VERS"
    echo "Dashboard and monitoring images values set"
 
    echo "Deploying alertmanager, grafana, node-exporter and prometheus"
@@ -207,15 +208,18 @@ function init() {
    ceph orch apply node-exporter
    ceph orch apply prometheus
 
-   for SERVICE in mon mgr osd mds client
-    do
-     CURRENT_IMG_VALUE=$(ceph config get $SERVICE container_image)
-     echo "Current image value for $SERVICE is $CURRENT_IMG_VALUE"
-     if [[ "$CURRENT_IMG_VALUE" != "$registry/ceph/ceph:v$CEPH_VERS" ]]
-     then
-      ceph config set $SERVICE container_image $registry/ceph/ceph:v$CEPH_VERS
-     fi
-    done
+## TEMP commenting out to test better method
+#
+#   for SERVICE in mon mgr osd mds client
+#    do
+#     CURRENT_IMG_VALUE=$(ceph config get $SERVICE container_image)
+#     echo "Current image value for $SERVICE is $CURRENT_IMG_VALUE"
+#     if [[ "$CURRENT_IMG_VALUE" != "$registry/ceph/ceph:v$CEPH_VERS" ]]
+#     then
+#      ceph config set $SERVICE container_image $registry/ceph/ceph:v$CEPH_VERS
+#     fi
+#    done
+##
 
    echo "Sleeping for 30 seconds to allow ceph devices to discover"
    sleep 30

--- a/boxes/ncn-node-images/storage-ceph/files/scripts/metal/lib-1.5.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/metal/lib-1.5.sh
@@ -208,19 +208,6 @@ function init() {
    ceph orch apply node-exporter
    ceph orch apply prometheus
 
-## TEMP commenting out to test better method
-#
-#   for SERVICE in mon mgr osd mds client
-#    do
-#     CURRENT_IMG_VALUE=$(ceph config get $SERVICE container_image)
-#     echo "Current image value for $SERVICE is $CURRENT_IMG_VALUE"
-#     if [[ "$CURRENT_IMG_VALUE" != "$registry/ceph/ceph:v$CEPH_VERS" ]]
-#     then
-#      ceph config set $SERVICE container_image $registry/ceph/ceph:v$CEPH_VERS
-#     fi
-#    done
-##
-
    echo "Sleeping for 30 seconds to allow ceph devices to discover"
    sleep 30
 

--- a/boxes/ncn-node-images/storage-ceph/files/scripts/metal/lib-1.5.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/metal/lib-1.5.sh
@@ -198,8 +198,8 @@ function init() {
    ceph config set mgr mgr/cephadm/container_image_prometheus    "$registry/prometheus/prometheus:v2.18.1"
    ceph config set mgr mgr/cephadm/container_image_alertmanager  "$registry/quay.io/prometheus/alertmanager:v0.21.0"
    ceph config set mgr mgr/cephadm/container_image_node_exporter "$registry/quay.io/prometheus/node-exporter:v1.2.2"
-   ceph config set mgr mgr/cephadm/container_image_base "$regsistry/ceph/ceph:$CEPH_VERS"
-   ceph config set glocal container_image "$regsistry/ceph/ceph:$CEPH_VERS"
+   ceph config set mgr mgr/cephadm/container_image_base "$registry/ceph/ceph:v$CEPH_VERS"
+   ceph config set global container_image "$registry/ceph/ceph:v$CEPH_VERS"
    echo "Dashboard and monitoring images values set"
 
    echo "Deploying alertmanager, grafana, node-exporter and prometheus"

--- a/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
@@ -3,7 +3,7 @@
 set -e
 
 kubernetes_version="1.20.13-0"
-ceph_version='15.2.12.83+g528da226523-3.25.1'
+ceph_version='15.2.14.84+gb6e5642e260-3.31.1'
 ansible_version='2.9.21'
 mkdir -p /etc/kubernetes
 echo "export KUBECONFIG=\"/etc/kubernetes/admin.conf\"" >> /etc/profile.d/cray.sh
@@ -50,9 +50,9 @@ systemctl start podman
 podman pull arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.8
 podman tag arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.8 registry.local/ceph/ceph:v15.2.8
 podman rmi arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.8
-podman pull arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.12
-podman tag arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.12 registry.local/ceph/ceph:v15.2.12
-podman rmi arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.12
+podman pull arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.15
+podman tag arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.15 registry.local/ceph/ceph:v15.2.15
+podman rmi arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.15
 podman pull arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/alertmanager:v0.20.0
 podman tag arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/alertmanager:v0.20.0 registry.local/prometheus/alertmanager:v0.20.0
 podman rmi arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/alertmanager:v0.20.0
@@ -89,7 +89,7 @@ echo "Saving ceph image to tar file as backup"
 # done
 
 podman save registry.local/ceph/ceph:v15.2.8 -o /srv/cray/resources/common/images/ceph_v15.2.8.tar
-podman save registry.local/ceph/ceph:v15.2.12 -o /srv/cray/resources/common/images/ceph_v15.2.12.tar
+podman save registry.local/ceph/ceph:v15.2.15 -o /srv/cray/resources/common/images/ceph_v15.2.15.tar
 podman save registry.local/prometheus/alertmanager:v0.20.0 -o /srv/cray/resources/common/images/alertmanager_v0.20.0.tar
 podman save registry.local/prometheus/alertmanager:v0.21.0 -o /srv/cray/resources/common/images/alertmanager_v0.21.0.tar
 podman save registry.local/prometheus/node-exporter:v0.18.1 -o /srv/cray/resources/common/images/node-exporter_v0.18.1.tar

--- a/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
@@ -50,9 +50,9 @@ systemctl start podman
 podman pull arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.8
 podman tag arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.8 registry.local/ceph/ceph:v15.2.8
 podman rmi arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.8
-podman pull arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.15
-podman tag arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.15 registry.local/ceph/ceph:v15.2.15
-podman rmi arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.15
+podman pull artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15
+podman tag artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15 registry.local/ceph/ceph:v15.2.15
+podman rmi artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15
 podman pull arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/alertmanager:v0.20.0
 podman tag arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/alertmanager:v0.20.0 registry.local/prometheus/alertmanager:v0.20.0
 podman rmi arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/alertmanager:v0.20.0


### PR DESCRIPTION
This also bumps ceph-common

This only pre-pulls the image.  it does not install it

#### Summary and Scope

- Fixes # CASMPET-5328

##### Issue Type

- planned upgrade target

This version of ceph contains cve fixes and is based of the centos:stream8 container image

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
n/a
 
#### Risks and Mitigations
 
n/a
