### PR TITLE
 CASMINST-3874: change lacp-rate from slow to fast; form bond0 in cloud-init

### DIFF
--- a/boxes/ncn-common/files/resources/common/cloud/templates/cloud-init-network.tmpl
+++ b/boxes/ncn-common/files/resources/common/cloud/templates/cloud-init-network.tmpl
@@ -16,7 +16,7 @@ network:
       parameters:
         mode: 802.3ad
         mii-monitor-interval: 100
-        lacp-rate: slow
+        lacp-rate: fast
         ad-select: bandwidth
         transmit-hash-policy: layer2+3
   vlans:


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes CASMINST-3874
- Requires:
https://github.com/Cray-HPE/metal-ipxe/pull/31
https://github.com/Cray-HPE/cray-site-init/pull/122
- Relates to https://github.com/Cray-HPE/node-image-build/pull/141

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (redbull & surtur)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
