### PR TITLE
CASMINST-3780: consolidate wicked actions / harden

### DIFF
--- a/boxes/ncn-common/files/scripts/metal/install.sh
+++ b/boxes/ncn-common/files/scripts/metal/install.sh
@@ -13,8 +13,6 @@ breakaway() {
     # clean bootstrap/ephemeral TCP/IP information
     (
         set -x
-        write_default_route
-        clean_bogies
         drop_metal_tcp_ip bond0
         remove_fs_overwrite
     ) 2>/var/log/cloud-init-metal-breakaway.error

--- a/boxes/ncn-common/files/scripts/metal/install.sh
+++ b/boxes/ncn-common/files/scripts/metal/install.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 # Author: Russell Bunch <doomslayer@hpe.com>
 trap "printf >&2 'Metal Install: [ % -20s ]' 'failed'" ERR TERM HUP INT
 trap "echo 'See logfile at: /var/log/cloud-init-metal.log'" EXIT

--- a/boxes/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/boxes/ncn-common/files/scripts/metal/metal-lib.sh
@@ -252,14 +252,6 @@ function enable_amsd() {
     esac
 }
 
-function clean_bogies {
-    # removing eth0 configs
-    # ALWAYS DO THIS; THESE SHOULD NOT EXIST IN METAL
-    # Any interface file that exists is tracked by wicked, if the interface does
-    # not actually exist in reality then wicked will complain. Remove the needless files.
-    rm -rfv /etc/sysconfig/network/*eth*
-}
-
 function drop_metal_tcp_ip {
     local nic=$1
     [ -z "$nic" ] && return 0
@@ -275,16 +267,6 @@ function drop_metal_tcp_ip {
         echo "Deleting ephemeral bootstrap IP $ip6addr from $nic"
         ip a d $ip6addr dev $nic
     fi
-}
-
-function write_default_route {
-    # Setup the route
-    # ALWAYS CLOBBER; ROUTE SHOULD ALWAYS BE THE SAME
-    # CLOBBER=UPDATE; ALWAYS UPDATE.
-    local gw
-    local nic=bond0.cmn0
-    gw=$(craysys metadata get --level node ipam | jq .cmn.gateway | tr -d '"')
-    echo "default ${gw} - $nic" >/etc/sysconfig/network/ifroute-$nic && wicked ifreload all || systemctl restart wickedd && sleep 3
 }
 
 # This will let the order fall into however the BIOS wants it; grouping netboot, disk, and removable options.

--- a/boxes/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/boxes/ncn-common/files/scripts/metal/metal-lib.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
 # to deal in the Software without restriction, including without limitation
@@ -12,14 +16,12 @@
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# (MIT License)
-
 # shellcheck disable=SC2086,SC2046,SC2010
 
 fslabel=BOOTRAID

--- a/boxes/ncn-common/files/scripts/metal/net-init.sh
+++ b/boxes/ncn-common/files/scripts/metal/net-init.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 # don't complain about unquoted vars / word splitting
 # shellcheck disable=SC2086

--- a/boxes/ncn-common/files/scripts/metal/net-init.sh
+++ b/boxes/ncn-common/files/scripts/metal/net-init.sh
@@ -31,6 +31,9 @@ cloud-init query --format="$(cat /etc/cloud/templates/hosts.suse.tmpl)" >/etc/ho
 # once to generate the ifcfg files,
 # and again to reload cloud-init metadata after network daemons restart.
 function ifconf() {
+    local gw
+    local nic=bond0.cmn0
+
     # Render the template
     printf 'net-init: [ % -20s ]\n' 'running: sysconfig'
     cloud-init query --format="$(cat /etc/cloud/templates/cloud-init-network.tmpl)" >/etc/cloud/cloud.cfg.d/00_network.cfg || fail_and_die "cloud-init query failed to render cloud-init-network.tmpl"


### PR DESCRIPTION
#### Summary and Scope

* Make it a hard/fatal error if we can't get the
  default route from craysys
* Move the generation of the default route file
  into net-init.sh, thus reducing to 1 the number
  of times we invoke wicked.
* Move the removal of the 'eth' configs to net-init.sh
   prior to reloading interfaces.
* Remove one sleep and reduce the duration of the sleep
   after reloading interfaces.

- Fixes CASMINST-3780

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (redbull)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 