### PR TITLE
Latest Pre-release 0.2.58

### DIFF
--- a/boxes/ncn-common/files/resources/common/cloud/templates/resolv.conf.tmpl
+++ b/boxes/ncn-common/files/resources/common/cloud/templates/resolv.conf.tmpl
@@ -4,6 +4,9 @@
 # that it has been provided. Cloud-init, by default, will write this file
 # a single time (PER_ONCE).
 #
+# Custom options
+options single-request-reopen
+
 {% if ds.meta_data.Global.domain is defined %}
 search {% for search in ds.meta_data.Global.domain.split() %}{{ search }} {% endfor %}
 {% endif %}

--- a/boxes/ncn-common/files/scripts/metal/install.sh
+++ b/boxes/ncn-common/files/scripts/metal/install.sh
@@ -13,8 +13,6 @@ breakaway() {
     # clean bootstrap/ephemeral TCP/IP information
     (
         set -x
-        write_default_route
-        clean_bogies
         drop_metal_tcp_ip bond0
         remove_fs_overwrite
     ) 2>/var/log/cloud-init-metal-breakaway.error

--- a/boxes/ncn-common/files/scripts/metal/install.sh
+++ b/boxes/ncn-common/files/scripts/metal/install.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 # Author: Russell Bunch <doomslayer@hpe.com>
 trap "printf >&2 'Metal Install: [ % -20s ]' 'failed'" ERR TERM HUP INT
 trap "echo 'See logfile at: /var/log/cloud-init-metal.log'" EXIT

--- a/boxes/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/boxes/ncn-common/files/scripts/metal/metal-lib.sh
@@ -252,14 +252,6 @@ function enable_amsd() {
     esac
 }
 
-function clean_bogies {
-    # removing eth0 configs
-    # ALWAYS DO THIS; THESE SHOULD NOT EXIST IN METAL
-    # Any interface file that exists is tracked by wicked, if the interface does
-    # not actually exist in reality then wicked will complain. Remove the needless files.
-    rm -rfv /etc/sysconfig/network/*eth*
-}
-
 function drop_metal_tcp_ip {
     local nic=$1
     [ -z "$nic" ] && return 0
@@ -275,16 +267,6 @@ function drop_metal_tcp_ip {
         echo "Deleting ephemeral bootstrap IP $ip6addr from $nic"
         ip a d $ip6addr dev $nic
     fi
-}
-
-function write_default_route {
-    # Setup the route
-    # ALWAYS CLOBBER; ROUTE SHOULD ALWAYS BE THE SAME
-    # CLOBBER=UPDATE; ALWAYS UPDATE.
-    local gw
-    local nic=bond0.cmn0
-    gw=$(craysys metadata get --level node ipam | jq .cmn.gateway | tr -d '"')
-    echo "default ${gw} - $nic" >/etc/sysconfig/network/ifroute-$nic && wicked ifreload all || systemctl restart wickedd && sleep 3
 }
 
 # This will let the order fall into however the BIOS wants it; grouping netboot, disk, and removable options.

--- a/boxes/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/boxes/ncn-common/files/scripts/metal/metal-lib.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
 # to deal in the Software without restriction, including without limitation
@@ -12,14 +16,12 @@
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# (MIT License)
-
 # shellcheck disable=SC2086,SC2046,SC2010
 
 fslabel=BOOTRAID

--- a/boxes/ncn-common/files/scripts/metal/net-init.sh
+++ b/boxes/ncn-common/files/scripts/metal/net-init.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 # don't complain about unquoted vars / word splitting
 # shellcheck disable=SC2086

--- a/boxes/ncn-common/files/scripts/metal/net-init.sh
+++ b/boxes/ncn-common/files/scripts/metal/net-init.sh
@@ -31,6 +31,9 @@ cloud-init query --format="$(cat /etc/cloud/templates/hosts.suse.tmpl)" >/etc/ho
 # once to generate the ifcfg files,
 # and again to reload cloud-init metadata after network daemons restart.
 function ifconf() {
+    local gw
+    local nic=bond0.cmn0
+
     # Render the template
     printf 'net-init: [ % -20s ]\n' 'running: sysconfig'
     cloud-init query --format="$(cat /etc/cloud/templates/cloud-init-network.tmpl)" >/etc/cloud/cloud.cfg.d/00_network.cfg || fail_and_die "cloud-init query failed to render cloud-init-network.tmpl"

--- a/boxes/ncn-node-images/storage-ceph/files/scripts/common/pre-load-images.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/common/pre-load-images.sh
@@ -12,6 +12,7 @@ echo "Pre-loading local images"
 
 podman image load registry.local/ceph/ceph:v15.2.8 -i /srv/cray/resources/common/images/ceph_v15.2.8.tar
 podman image load registry.local/ceph/ceph:v15.2.15 -i /srv/cray/resources/common/images/ceph_v15.2.15.tar
+podman tag  registry.local/ceph/ceph:v15.2.15 registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15
 podman image load registry.local/ceph/ceph-grafana:6.6.2 -i /srv/cray/resources/common/images/ceph-grafana_6.6.2.tar
 podman image load registry.local/ceph/ceph-grafana:6.7.4 -i /srv/cray/resources/common/images/ceph-grafana_6.7.4.tar
 podman image load registry.local/quay.io/prometheus/prometheus:v2.18.1 -i /srv/cray/resources/common/images/prometheus_v2.18.1.tar

--- a/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
@@ -68,9 +68,9 @@ podman rmi  artifactory.algol60.net/csm-docker/stable/ceph/ceph-grafana:6.6.2
 podman pull artifactory.algol60.net/csm-docker/stable/ceph/ceph-grafana:6.7.4
 podman tag  artifactory.algol60.net/csm-docker/stable/ceph/ceph-grafana:6.7.4 registry.local/ceph/ceph-grafana:6.7.4
 podman rmi  artifactory.algol60.net/csm-docker/stable/ceph/ceph-grafana:6.7.4
-podman pull artifactory.algol60.net/csm-docker/stable/prometheus/prometheus:v2.18.1
-podman tag  artifactory.algol60.net/csm-docker/stable/prometheus/prometheus:v2.18.1 registry.local/prometheus/prometheus:v2.18.1
-podman tag  artifactory.algol60.net/csm-docker/stable/prometheus/prometheus:v2.18.1 registry.local/quay.io/prometheus/prometheus:v2.18.1 
+podman pull artifactory.algol60.net/csm-docker/stable/prometheus:v2.18.1
+podman tag  artifactory.algol60.net/csm-docker/stable/prometheus:v2.18.1 registry.local/prometheus/prometheus:v2.18.1
+podman tag  artifactory.algol60.net/csm-docker/stable/prometheus:v2.18.1 registry.local/quay.io/prometheus/prometheus:v2.18.1 
 
 podman rmi arti.dev.cray.com:443/docker-stable-local/prometheus/prometheus:v2.18.1
 echo "Image pull complete"

--- a/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
@@ -52,6 +52,7 @@ podman tag  artifactory.algol60.net/csm-docker/stable/ceph/ceph:v15.2.8 registry
 podman rmi  artifactory.algol60.net/csm-docker/stable/ceph/ceph:v15.2.8
 podman pull artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15
 podman tag  artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15 registry.local/ceph/ceph:v15.2.15
+podman tag  artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15 registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15
 podman rmi  artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15
 podman pull artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/alertmanager:v0.20.0
 podman tag  artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/alertmanager:v0.20.0 registry.local/prometheus/alertmanager:v0.20.0

--- a/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
@@ -71,8 +71,8 @@ podman rmi  artifactory.algol60.net/csm-docker/stable/ceph/ceph-grafana:6.7.4
 podman pull artifactory.algol60.net/csm-docker/stable/prometheus:v2.18.1
 podman tag  artifactory.algol60.net/csm-docker/stable/prometheus:v2.18.1 registry.local/prometheus/prometheus:v2.18.1
 podman tag  artifactory.algol60.net/csm-docker/stable/prometheus:v2.18.1 registry.local/quay.io/prometheus/prometheus:v2.18.1 
+podman rmi  artifactory.algol60.net/csm-docker/stable/prometheus:v2.18.1
 
-podman rmi arti.dev.cray.com:443/docker-stable-local/prometheus/prometheus:v2.18.1
 echo "Image pull complete"
 
 echo "Saving ceph image to tar file as backup"

--- a/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
@@ -47,33 +47,30 @@ systemctl start podman
 
 # Note to clean this up.  CASMINST-2148
 
-podman pull arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.8
-podman tag arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.8 registry.local/ceph/ceph:v15.2.8
-podman rmi arti.dev.cray.com/third-party-docker-stable-local/ceph/ceph:v15.2.8
+podman pull artifactory.algol60.net/csm-docker/stable/ceph/ceph:v15.2.8
+podman tag  artifactory.algol60.net/csm-docker/stable/ceph/ceph:v15.2.8 registry.local/ceph/ceph:v15.2.8
+podman rmi  artifactory.algol60.net/csm-docker/stable/ceph/ceph:v15.2.8
 podman pull artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15
-podman tag artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15 registry.local/ceph/ceph:v15.2.15
-podman rmi artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15
-podman pull arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/alertmanager:v0.20.0
-podman tag arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/alertmanager:v0.20.0 registry.local/prometheus/alertmanager:v0.20.0
-podman rmi arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/alertmanager:v0.20.0
-podman pull arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/alertmanager:v0.21.0
-podman tag arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/alertmanager:v0.21.0 registry.local/prometheus/alertmanager:v0.21.0
-podman rmi arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/alertmanager:v0.21.0
-podman pull arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/node-exporter:v0.18.1
-podman tag arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/node-exporter:v0.18.1 registry.local/prometheus/node-exporter:v0.18.1
-podman rmi arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/node-exporter:v0.18.1
-podman pull arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/node-exporter:v1.2.2
-podman tag arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/node-exporter:v1.2.2 registry.local/prometheus/node-exporter:v1.2.2
-podman rmi arti.dev.cray.com/third-party-docker-stable-local/quay.io/prometheus/node-exporter:v1.2.2
-podman pull arti.dev.cray.com:443/docker-stable-local/ceph/ceph-grafana:6.6.2
-podman tag arti.dev.cray.com:443/docker-stable-local/ceph/ceph-grafana:6.6.2 registry.local/ceph/ceph-grafana:6.6.2
-podman rmi arti.dev.cray.com:443/docker-stable-local/ceph/ceph-grafana:6.6.2
-podman pull arti.dev.cray.com:443/docker-stable-local/ceph/ceph-grafana:6.7.4
-podman tag arti.dev.cray.com:443/docker-stable-local/ceph/ceph-grafana:6.7.4 registry.local/ceph/ceph-grafana:6.7.4
-podman rmi arti.dev.cray.com:443/docker-stable-local/ceph/ceph-grafana:6.7.4
-podman pull arti.dev.cray.com:443/docker-stable-local/prometheus/prometheus:v2.18.1
-podman tag arti.dev.cray.com:443/docker-stable-local/prometheus/prometheus:v2.18.1 registry.local/prometheus/prometheus:v2.18.1
-podman tag arti.dev.cray.com:443/docker-stable-local/prometheus/prometheus:v2.18.1 registry.local/quay.io/prometheus/prometheus:v2.18.1 
+podman tag  artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15 registry.local/ceph/ceph:v15.2.15
+podman rmi  artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15
+podman pull artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/alertmanager:v0.20.0
+podman tag  artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/alertmanager:v0.20.0 registry.local/prometheus/alertmanager:v0.20.0
+podman rmi  artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/alertmanager:v0.20.0
+podman pull artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/alertmanager:v0.21.0
+podman tag  artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/alertmanager:v0.21.0 registry.local/prometheus/alertmanager:v0.21.0
+podman rmi  artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/alertmanager:v0.21.0
+podman pull artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/node-exporter:v1.2.2
+podman tag  artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/node-exporter:v1.2.2 registry.local/prometheus/node-exporter:v1.2.2
+podman rmi  artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/node-exporter:v1.2.2
+podman pull artifactory.algol60.net/csm-docker/stable/ceph/ceph-grafana:6.6.2
+podman tag  artifactory.algol60.net/csm-docker/stable/ceph/ceph-grafana:6.6.2 registry.local/ceph/ceph-grafana:6.6.2
+podman rmi  artifactory.algol60.net/csm-docker/stable/ceph/ceph-grafana:6.6.2
+podman pull artifactory.algol60.net/csm-docker/stable/ceph/ceph-grafana:6.7.4
+podman tag  artifactory.algol60.net/csm-docker/stable/ceph/ceph-grafana:6.7.4 registry.local/ceph/ceph-grafana:6.7.4
+podman rmi  artifactory.algol60.net/csm-docker/stable/ceph/ceph-grafana:6.7.4
+podman pull artifactory.algol60.net/csm-docker/stable/prometheus/prometheus:v2.18.1
+podman tag  artifactory.algol60.net/csm-docker/stable/prometheus/prometheus:v2.18.1 registry.local/prometheus/prometheus:v2.18.1
+podman tag  artifactory.algol60.net/csm-docker/stable/prometheus/prometheus:v2.18.1 registry.local/quay.io/prometheus/prometheus:v2.18.1 
 
 podman rmi arti.dev.cray.com:443/docker-stable-local/prometheus/prometheus:v2.18.1
 echo "Image pull complete"
@@ -92,7 +89,6 @@ podman save registry.local/ceph/ceph:v15.2.8 -o /srv/cray/resources/common/image
 podman save registry.local/ceph/ceph:v15.2.15 -o /srv/cray/resources/common/images/ceph_v15.2.15.tar
 podman save registry.local/prometheus/alertmanager:v0.20.0 -o /srv/cray/resources/common/images/alertmanager_v0.20.0.tar
 podman save registry.local/prometheus/alertmanager:v0.21.0 -o /srv/cray/resources/common/images/alertmanager_v0.21.0.tar
-podman save registry.local/prometheus/node-exporter:v0.18.1 -o /srv/cray/resources/common/images/node-exporter_v0.18.1.tar
 podman save registry.local/prometheus/node-exporter:v1.2.2 -o /srv/cray/resources/common/images/node-exporter_v1.2.2.tar
 podman save registry.local/ceph/ceph-grafana:6.6.2 -o /srv/cray/resources/common/images/ceph-grafana_6.6.2.tar
 podman save registry.local/ceph/ceph-grafana:6.7.4 -o /srv/cray/resources/common/images/ceph-grafana_6.7.4.tar


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes CASMTRIAGE-3006, CASMINST-3780, CASMINST-4052

Contains the following commits:
```
8731c02 (HEAD -> develop, origin/develop, origin/HEAD, origin/CASMINST-3780, CASMINST-3780) Add MIT license
ac54ecf CASMINST-3780: consolidate wicked actions / harden
642f909 shellcheck & formatting cleanup
09862f5 (origin/CASMINST-4052, CASMINST-4052) Fix image path so it will work with nexus
13c2520 Fixing untag for prometheus image
208a30e Fixing prometheus image path
545c7df Update image localtions from arti.dev to arti.algol60
6e74c78 (origin/CASMTRIAGE-3006) CASMTRIAGE-3006: Add options single-request-reopen to resolv.conf
```

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request


<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (redbull)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 