### PR TITLE
MGTL-1626 update to limit bond repair to only mgmt0 and mgmt1

### DIFF
--- a/boxes/ncn-common/files/scripts/metal/net-init.sh
+++ b/boxes/ncn-common/files/scripts/metal/net-init.sh
@@ -98,7 +98,7 @@ function ifconf() {
     ip a show mgmt1
     ip a show bond0
 
-    unenslavednic=$(ip a | grep -v SLAVE | awk -F': ' /mgmt/'{print $2}')
+    unenslavednic=$(ip a | grep -v SLAVE | awk -F': ' /mgmt[01]/'{print $2}')
     if [[ "$unenslavednic" =~ mgmt ]]; then
         printf 'net-init: [ % -20s ]\n' 'repairing bond0'
         ip link set $unenslavednic down


### PR DESCRIPTION
Update to limit the match only mgmt0 and mgmt1

#### Summary and Scope
Fixes MTL-1626 so we regex match on only mgmt0 or mgmt1 and not on any other mgmt nics we might see in an upgrade that used to be called sun nics.

- Fixes #MTL-1626
- Requires #
- Relates to #

##### Issue Type

- Bugfix Pull Request

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
