### PR TITLE
Pre-release of 0.2.60

### DIFF
--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/cray-pre-install-toolkit/base.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/cray-pre-install-toolkit/base.packages
@@ -8,10 +8,10 @@ loftsman=1.2.0-1
 manifestgen=1.3.4-1~development~bbba190
 
 # CSM METAL-team Packages
-cray-site-init=1.16.0-1
+cray-site-init=1.16.1-1
 ilorest=3.2.3-1
 metal-basecamp=1.1.9-1
-metal-ipxe=2.2.1-1
+metal-ipxe=2.2.3-1
 metal-net-scripts=0.0.2-1
 pit-init=1.2.14-1
 pit-nexus=1.1.0-1.1
@@ -73,3 +73,4 @@ which=2.21-2.20
 wireshark=3.4.7-3.59.1
 wol=0.7.1-2.5
 zip=3.0-2.22
+zsh=5.6-5.17

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/base.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.32
 
 # CSM Testing Utils
-goss-servers=1.12.6-1
+goss-servers=1.12.7-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 
@@ -122,3 +122,4 @@ wget=1.20.3-3.12.1
 wireshark=3.4.7-3.59.1
 xfsdump=3.1.6-1.30
 zip=3.0-2.22
+zsh=5.6-5.17


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes [CASMTRIAGE-3036](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3036)

##### Issue Type
<!--- Delete un-needed bullets -->

- RFE Pull Request

This change updates the `csm-rpms` vendored to the latest (`c9507be176fa20a9da0d2c6d2297489e87da8eb9`).  It contains two changes for NCN images:
* updated goss-servers package
* adds `zsh` as an available shell

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (redbull)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
