### PR TITLE
MTL-1616: fixup broken systemd services

### DIFF
--- a/boxes/ncn-common/provisioners/common/setup.sh
+++ b/boxes/ncn-common/provisioners/common/setup.sh
@@ -1,9 +1,32 @@
 #!/bin/bash
-
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 set -e
 
 echo "Initializing log location(s)"
 mkdir -p /var/log/cray
+touch /var/log/cray/no.log
 cat << 'EOF' > /etc/logrotate.d/cray
 /var/log/cray/*.log {
   size 1M

--- a/boxes/ncn-node-images/k8s/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/k8s/provisioners/common/install.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 set -e
 
@@ -92,7 +115,6 @@ ip_vs
 ip_vs_rr
 ip_vs_wrr
 ip_vs_sh
-nf_conntrack_ipv4
 br_netfilter
 EOF
 modprobe $(tr '\n' ' '< /usr/lib/modules-load.d/01-ipvs.conf)

--- a/boxes/sles15-base/http/autoinst.template.xml
+++ b/boxes/sles15-base/http/autoinst.template.xml
@@ -98,7 +98,7 @@
           <size>max</size>
           <filesystem config:type="symbol">ext4</filesystem>
           <mountby config:type="symbol">label</mountby>
-          <label>SQUASHFS</label>
+          <label>SQFSRAID</label>
         </partition>
       </partitions>
     </drive>


### PR DESCRIPTION
#### Summary and Scope

* create an empty no.log file so the /var/log/cray/*.log glob
  matches at least one file
* remove  nf_conntrack_ipv4, this is deprecated:
```
Mar 02 22:16:13 localhost systemd-modules-load[743]: Failed to find module 'nf_conntrack_ipv4'
```

```
ncn-m002:~ # lsmod | grep -w ^nf_conntrack
nf_conntrack          176128  8 xt_conntrack,nf_nat,xt_state,openvswitch,nf_conntrack_netlink,nf_conncount,xt_MASQUERADE,ip_vs
ncn-m002:~ #
```

- Fixes MTL-1616

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request


<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (redbull)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 