### PR TITLE
Configure podman so it will run with fuse-overlayfs

### DIFF
--- a/boxes/ncn-common/provisioners/common/install.sh
+++ b/boxes/ncn-common/provisioners/common/install.sh
@@ -6,6 +6,9 @@ echo "Ensuring /srv/cray/utilities locations are available for use system-wide"
 ln -s /srv/cray/utilities/common/craysys/craysys /bin/craysys
 echo "export PYTHONPATH=\"/srv/cray/utilities/common\"" >> /etc/profile.d/cray.sh
 
+echo "Configuring podman so it will run with fuse-overlayfs"
+sed -i 's/.*mount_program =.*/mount_program = "\/usr\/bin\/fuse-overlayfs"/' /etc/containers/storage.conf
+
 echo "Enabling services"
 systemctl enable multi-user.target
 systemctl set-default multi-user.target


### PR DESCRIPTION
#### Summary and Scope

- Fixes https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3076

Tested on craystack:

```
ncn-m001:~ # grep fuse /etc/containers/storage.conf
mount_program = "/usr/bin/fuse-overlayfs"
ncn-m001:~ # podman ps
CONTAINER ID  IMAGE   COMMAND  CREATED  STATUS  PORTS   NAMES
```

##### Issue Type

- Bugfix Pull Request

podman not running after 1.2 fresh installs, default config of podman does not use fuse-overlayfs.  This code was tested on wasp and fixed podman/ims tests issue..

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
Change can be run mutiple times
 
#### Risks and Mitigations
 
Low