### PR TITLE
MTL-1637: harden paginate function

### DIFF
--- a/boxes/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/boxes/ncn-common/files/scripts/metal/metal-lib.sh
@@ -437,11 +437,28 @@ EOM
 function paginate() {
     local url="$1"
     local token
+
+    if test -z $url; then
+        echo "ERROR: paginate() called without an argument"
+        exit 1
+    fi
+
     { token="$(curl -sSk "$url" | tee /dev/fd/3 | jq -r '.continuationToken // null')"; } 3>&1
+
+    if test -z $token; then
+        echo "ERROR on line $LINENO: unable to retreive continuation token, exiting"
+        exit 1
+    fi
+
     until [[ "$token" == "null" ]]; do
         {
             token="$(curl -sSk "$url&continuationToken=${token}" | tee /dev/fd/3 | jq -r '.continuationToken // null')";
         } 3>&1
+
+        if test -z $token; then
+            echo "ERROR on line $LINENO: unable to retreive continuation token, exiting"
+            exit 1
+        fi
     done
 }
 


### PR DESCRIPTION
#### Summary and Scope

CASMTRIAGE-3079 documents an instance of apparent corruption in
the bash execution environment.  As a result, a function with
poor error checking was looping forever.  Add checks for unset
variables and exit with an error if they are unset.

<!--- Pick one below and delete the rest -->

- Fixes MTL-1637
- Relates to CASMTRIAGE-3079

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request


<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (redbull, mug)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
N/A
 
#### Risks and Mitigations
 
N/A