### PR TITLE
Changing path for ceph v15.2.8 container image so we are pulling the …

### DIFF
--- a/boxes/ncn-node-images/storage-ceph/files/scripts/common/pre-load-images.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/common/pre-load-images.sh
@@ -10,15 +10,15 @@ echo "Pre-loading local images"
 #  podman image load "registry.local/$name:$tag" -i $image_path$image_file
 # done
 
-podman image load registry.local/ceph/ceph:v15.2.8 -i /srv/cray/resources/common/images/ceph_v15.2.8.tar
-podman image load registry.local/ceph/ceph:v15.2.15 -i /srv/cray/resources/common/images/ceph_v15.2.15.tar
+podman image load -i /srv/cray/resources/common/images/ceph_v15.2.8.tar
+podman image load -i /srv/cray/resources/common/images/ceph_v15.2.15.tar
 podman tag  registry.local/ceph/ceph:v15.2.15 registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15
-podman image load registry.local/ceph/ceph-grafana:6.6.2 -i /srv/cray/resources/common/images/ceph-grafana_6.6.2.tar
-podman image load registry.local/ceph/ceph-grafana:6.7.4 -i /srv/cray/resources/common/images/ceph-grafana_6.7.4.tar
-podman image load registry.local/quay.io/prometheus/prometheus:v2.18.1 -i /srv/cray/resources/common/images/prometheus_v2.18.1.tar
-podman image load registry.local/quay.io/prometheus/alertmanager:v0.20.0 -i /srv/cray/resources/common/images/alertmanager_v0.20.0.tar
-podman image load registry.local/quay.io/prometheus/alertmanager:v0.21.0 -i /srv/cray/resources/common/images/alertmanager_v0.21.0.tar
-podman image load registry.local/quay.io/prometheus/node-exporter:v0.18.1 -i /srv/cray/resources/common/images/node-exporter_v0.18.1.tar
-podman image load registry.local/quay.io/prometheus/node-exporter:v1.2.2 -i /srv/cray/resources/common/images/node-exporter_v1.2.2.tar
+podman image load -i /srv/cray/resources/common/images/ceph-grafana_6.6.2.tar
+podman image load -i /srv/cray/resources/common/images/ceph-grafana_6.7.4.tar
+podman image load -i /srv/cray/resources/common/images/prometheus_v2.18.1.tar
+podman image load -i /srv/cray/resources/common/images/alertmanager_v0.20.0.tar
+podman image load -i /srv/cray/resources/common/images/alertmanager_v0.21.0.tar
+podman image load -i /srv/cray/resources/common/images/node-exporter_v0.18.1.tar
+podman image load -i /srv/cray/resources/common/images/node-exporter_v1.2.2.tar
 
 echo "Images loaded"

--- a/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
@@ -62,7 +62,7 @@ podman tag  artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/alertma
 podman rmi  artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/alertmanager:v0.21.0
 podman pull artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/node-exporter:v1.2.2
 podman tag  artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/node-exporter:v1.2.2 registry.local/prometheus/node-exporter:v1.2.2
-podman tag  artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/node-exporter:v1.2.2 registry.local/iquay.io/prometheus/node-exporter:v1.2.2
+podman tag  artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/node-exporter:v1.2.2 registry.local/quay.io/prometheus/node-exporter:v1.2.2
 podman rmi  artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/node-exporter:v1.2.2
 podman pull artifactory.algol60.net/csm-docker/stable/ceph/ceph-grafana:6.6.2
 podman tag  artifactory.algol60.net/csm-docker/stable/ceph/ceph-grafana:6.6.2 registry.local/ceph/ceph-grafana:6.6.2

--- a/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
@@ -47,9 +47,9 @@ systemctl start podman
 
 # Note to clean this up.  CASMINST-2148
 
-podman pull artifactory.algol60.net/csm-docker/stable/ceph/ceph:v15.2.8
-podman tag  artifactory.algol60.net/csm-docker/stable/ceph/ceph:v15.2.8 registry.local/ceph/ceph:v15.2.8
-podman rmi  artifactory.algol60.net/csm-docker/stable/ceph/ceph:v15.2.8
+podman pull artifactory.algol60.net/csm-docker/stable/docker.io/ceph/ceph:v15.2.8
+podman tag  artifactory.algol60.net/csm-docker/stable/docker.io/ceph/ceph:v15.2.8 registry.local/ceph/ceph:v15.2.8
+podman rmi  artifactory.algol60.net/csm-docker/stable/docker.io/ceph/ceph:v15.2.8
 podman pull artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15
 podman tag  artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15 registry.local/ceph/ceph:v15.2.15
 podman tag  artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15 registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15


### PR DESCRIPTION
#### Summary and Scope

we have multiple versions of the ceph v15.2.8 version.  adding docker.io to pull the correct image

- Fixes # CASMINST-4244

##### Issue Type

- Bugfix Pull Request

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
#### Risks and Mitigations
 
