### PR TITLE
CASMINST-4249 enable conman service

### DIFF
--- a/boxes/pit-common/provisioners/pit/services.sh
+++ b/boxes/pit-common/provisioners/pit/services.sh
@@ -4,6 +4,7 @@ set -e
 
 systemctl enable apache2
 systemctl enable basecamp
+systemctl enable conman
 systemctl enable chronyd
 systemctl enable dnsmasq
 systemctl enable nexus


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

#### Summary and Scope

- Fixes # CASMINST-4249
- Merge with https://github.com/Cray-HPE/cray-pre-install-toolkit/pull/30

##### Issue Type

- Bugfix Pull Request

Enables conman service to pass failing GOSS test.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
N/A
 
#### Risks and Mitigations
 
Low.
