### PR TITLE
CASMINST-4244 - fix pre-load images to handle missing images

### DIFF
--- a/boxes/ncn-node-images/storage-ceph/files/scripts/common/pre-load-images.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/common/pre-load-images.sh
@@ -18,7 +18,8 @@ podman image load -i /srv/cray/resources/common/images/ceph-grafana_6.7.4.tar
 podman image load -i /srv/cray/resources/common/images/prometheus_v2.18.1.tar
 podman image load -i /srv/cray/resources/common/images/alertmanager_v0.20.0.tar
 podman image load -i /srv/cray/resources/common/images/alertmanager_v0.21.0.tar
-podman image load -i /srv/cray/resources/common/images/node-exporter_v0.18.1.tar
+podman tag registry.local/prometheus/alertmanager:v0.21.0 registry.local/quay.io/prometheus/alertmanager:v0.21.0
 podman image load -i /srv/cray/resources/common/images/node-exporter_v1.2.2.tar
+podman tag registry.local/prometheus/node-exporter:v1.2.2 registry.local/quay.io/prometheus/node-exporter:v1.2.2
 
 echo "Images loaded"


### PR DESCRIPTION
#### Summary and Scope
The podman upgrade from 2.1.1 to 3.4.4 during the image build is
purging all the images.  They reload during boot but we had some additional tags
missing due to the image purge

- Fixes # CASMINST-4
- Requires #
- Relates to #

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
