### PR TITLE
MTL-1647: remove default root credentials from NC images

### DIFF
--- a/boxes/ncn-common/provisioners/common/setup.sh
+++ b/boxes/ncn-common/provisioners/common/setup.sh
@@ -43,54 +43,6 @@ rm -rf /tmp/files
 cp /srv/cray/sysctl/common/* /etc/sysctl.d/
 cp /srv/cray/limits/98-cray-limits.conf /etc/security/limits.d/98-cray-limits.conf
 
-# TODO: default root ssh key details should be parameterized. These keys should ALWAYS
-# be overridden at install/upgrade time based on customer configuration, and thus these
-# built-in ones should really only be relevant for any needed build-time needs. Nonetheless,
-# this should still not be hard-coded, it was just originally translated from previous build
-# scripts to reduce impact during transitional periods
-echo "Setting up default, initial root SSH configuration/credentials"
-mkdir -p /root/.ssh
-cat > /root/.ssh/id_rsa << EOF
------BEGIN RSA PRIVATE KEY-----
-MIIEogIBAAKCAQEArq+xyoMdc32q0rhB0DErNl8xK8AyXN1jfK0p89PsN/UCc9OC
-raRZ8xftD9uTgrQsGQBsInIJcxUlIApGfit+eQZBhycCSfW3IBt2g3JdGwFMGrT4
-llfC7pTLQS4IgHl9WmyKGRoiYlDdyAHWzSIcKYeyY6DFIM0zNV0FW7LwpbrtzxU8
-dh2vNjUBsojQjdY9YFgWytlOHz60s4k3yWMuXpRH2uLrv4ka3pr22Q+NTG+lMWAw
-Ukxo2Uhb/sdeAFroFxGjIuZxQBXjkLSWpPmAgoYMa72mJYiTJpHhXcGEnFaNbZz4
-ipgLtxdnMEaPymQkeGcUpIso8BJIt+AJp9uVkQIDAQABAoIBAH8BrNFhjOsoRifY
-4bjd1t48TcLShYtxR2EhgawOu+NfVv4hnRRktyWAktKBwfk4yAsRfI16vhYXHJvz
-/JbFRrn1a3U5Tne5mABXF06wurLkuZF9XHPqsQbH1hO4xWOrcRFqcumXT8KNqwI9
-HBCfKTyktXWsMUcNCptU2411R3Qmhil5wdgJQNrEl1qMiLOBeTrE5gEBh9nylIoC
-UW5tejBUX+9/LTFmyYb249Mb32aNPDDxe76PFTeNUvqYmh8xv1KbdD2sCIYWxmk+
-snUujljMxAETylepItFF0DOQsVwS8posvwRAgxsqKTDNaGma92Tbh33fSgNwjBDW
-zNO7y6UCgYEA17o8eUZucy0ifh4Kvmey7etT5Jvig9EtL8ZK4byCspd//FO0Q081
-FwK0YycYlP8YSO+mIAefU2YZC8qRPNqxW5/TmrvdObsXfy9TbmbnjXmcsQVdwHxv
-jHnoNgmOLqQdQGbqQ+jg2CPHSp+DjmdiQQ60lotny5moOs1YPTnT5C8CgYEAz0wS
-hDLi1XCULni7lKez/xj2EpfMDqRh9JwPAEA7+HYKf9Np7M1hz/X3ZlWKiXZxmgT5
-l1fRhwjTVMgneBfkmg0ePmxq+zzwnTC8OCbE3DMCw+SRXE6cCOxjsDXpBwqtWIn+
-B1k8c4cI+ebKUP+IAUvdDXbkPKbow9CbuNae8j8CgYAdKGToF2byVlVlKnZVSfrb
-QYVzTsaM/obXADw6ypn3vZZk6oNg3aHVXF45UJ139gq4QPv5NE6KnTAhcd2zlfOG
-6NFXBrFeDjWc0S67q1j8vEU7f/gt/iOtnwSN2TjIgRIbFE3xo9ZQIHXdVjYX101m
-cbBi8LC0yi381KhqjhhfrQKBgE5/Xw+ieVUb0XEblOTA8J8r45q80q/Evbc0FVYh
-/NOkV2t6MkVSrLRkTu/4eoJ9UJ1jPuR5g8VfqS8UsCWA3rcbOpWm1ogW1oKfvtaA
-j9FWm7h0aDsNJXcXlNRYRcq911CMyJ4dw4931gVTyM8NRIJBKQ79M4ZoKgJkj2Na
-GkxfAoGASe0i9N3Auk7opsDK+CgyujVuR2YF3hpro1fiW8Z8UWbseOPBnMTUVWZa
-gsXsdmcoFiHp3IcJ2aqjwrbTGnIduU00vn6IGBRTxI2upCIrawQN24Jqjgw/PJ17
-lp3iQ80542iRxFeV/XQTpUzR5dUWLOrD1kHtq28nmNcS6ZivWfE=
------END RSA PRIVATE KEY-----
-EOF
-cat > /root/.ssh/id_rsa.pub << EOF
-ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCur7HKgx1zfarSuEHQMSs2XzErwDJc3WN8rSnz0+w39QJz04KtpFnzF+0P25OCtCwZAGwicglzFSUgCkZ+K355BkGHJwJJ9bcgG3aDcl0bAUwatPiWV8LulMtBLgiAeX1abIoZGiJiUN3IAdbNIhwph7JjoMUgzTM1XQVbsvCluu3PFTx2Ha82NQGyiNCN1j1gWBbK2U4fPrSziTfJYy5elEfa4uu/iRremvbZD41Mb6UxYDBSTGjZSFv+x14AWugXEaMi5nFAFeOQtJak+YCChgxrvaYliJMmkeFdwYScVo1tnPiKmAu3F2cwRo/KZCR4ZxSkiyjwEki34Amn25WR
-EOF
-cat > /root/.ssh/authorized_keys << EOF
-ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCur7HKgx1zfarSuEHQMSs2XzErwDJc3WN8rSnz0+w39QJz04KtpFnzF+0P25OCtCwZAGwicglzFSUgCkZ+K355BkGHJwJJ9bcgG3aDcl0bAUwatPiWV8LulMtBLgiAeX1abIoZGiJiUN3IAdbNIhwph7JjoMUgzTM1XQVbsvCluu3PFTx2Ha82NQGyiNCN1j1gWBbK2U4fPrSziTfJYy5elEfa4uu/iRremvbZD41Mb6UxYDBSTGjZSFv+x14AWugXEaMi5nFAFeOQtJak+YCChgxrvaYliJMmkeFdwYScVo1tnPiKmAu3F2cwRo/KZCR4ZxSkiyjwEki34Amn25WR
-EOF
-chmod 600 /root/.ssh/id_rsa
-chmod 644 /root/.ssh/id_rsa.pub
-chmod 644 /root/.ssh/authorized_keys
-chmod 700 /root/.ssh
-chown -R root:root /root
-
 # Change hostname from lower layer to ncn.
 echo 'ncn' > /etc/hostname
 

--- a/boxes/ncn-node-images/k8s/files/tests/metal/goss-image-common.yaml
+++ b/boxes/ncn-node-images/k8s/files/tests/metal/goss-image-common.yaml
@@ -1,4 +1,29 @@
+#
+# MIT License
+#
+# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 file:
+  /root/.ssh:
+    exists: false
   /etc/zypp/services.d/Basesystem_Module_15_SP2_x86_64.service:
     exists: false
   /etc/zypp/services.d/Server_Applications_Module_15_SP2_x86_64.service:
@@ -22,3 +47,12 @@ service:
   cloud-init-local:
     enabled: true
     running: false
+command:
+  no_root_password:
+    exit-status: 0
+    exec: "grep root /etc/shadow"
+    stdout:
+    - root:*:18969::::::
+    stderr: []
+    timeout: 2000 # in milliseconds
+    skip: false

--- a/boxes/ncn-node-images/node-images.pkr.hcl
+++ b/boxes/ncn-node-images/node-images.pkr.hcl
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 source "virtualbox-ovf" "kubernetes" {
   source_path = "${var.vbox_source_path}"
   format = "${var.vbox_format}"
@@ -374,6 +397,14 @@ build {
       "virtualbox-ovf.kubernetes",
       "qemu.kubernetes",
       "virtualbox-ovf.storage-ceph",
+      "qemu.storage-ceph"
+    ]
+  }
+
+  provisioner "shell" {
+     script = "${path.root}/provisioners/metal/security.sh"
+    only = [
+      "qemu.kubernetes",
       "qemu.storage-ceph"
     ]
   }

--- a/boxes/ncn-node-images/provisioners/metal/security.sh
+++ b/boxes/ncn-node-images/provisioners/metal/security.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -ex
+
+sed -i '/^root:/c\root:\*:18969::::::' /etc/shadow
+rm -rf /root/.ssh

--- a/boxes/ncn-node-images/storage-ceph/files/tests/metal/goss-image-common.yaml
+++ b/boxes/ncn-node-images/storage-ceph/files/tests/metal/goss-image-common.yaml
@@ -1,4 +1,29 @@
+#
+# MIT License
+#
+# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 file:
+  /root/.ssh:
+    exists: false
   /etc/zypp/services.d/Basesystem_Module_15_SP2_x86_64.service:
     exists: false
   /etc/zypp/services.d/Server_Applications_Module_15_SP2_x86_64.service:
@@ -20,3 +45,12 @@ service:
   cloud-init-local:
     enabled: true
     running: false
+command:
+  no_root_password:
+    exit-status: 0
+    exec: "grep root /etc/shadow"
+    stdout:
+    - root:*:18969::::::
+    stderr: []
+    timeout: 2000 # in milliseconds
+    skip: false


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1647

- Sets default root password to "`*`" in `/etc/shadow`, disabling login as root
- Ensures there are no default ssh keys for root
- Adds build tests to validate the above
- Requires https://github.com/Cray-HPE/docs-csm/pull/1162

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (redbull)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
