### PR TITLE
MTL-1649: Allow VirtualBox build to use larger disk size from initial build.

### DIFF
--- a/boxes/sles15-base/base.pkr.hcl
+++ b/boxes/sles15-base/base.pkr.hcl
@@ -9,7 +9,7 @@ source "virtualbox-iso" "sles15-base" {
   boot_wait = "${var.boot_wait}"
   cpus = "${var.cpus}"
   memory = "${var.memory}"
-  disk_size = "${var.disk_size}"
+  disk_size = "${var.vbox_disk_size}"
   format = "${var.vbox_format}"
   guest_additions_path = "VBoxGuestAdditions_{{ .Version }}.iso"
   guest_os_type = "OpenSUSE_64"

--- a/boxes/sles15-base/variables.pkr.hcl
+++ b/boxes/sles15-base/variables.pkr.hcl
@@ -11,6 +11,14 @@ variable "cpus" {
 variable "disk_size" {
   type = string
   default = "8000"
+  description = "The initial disk size for QEMU builds."
+}
+
+variable "vbox_disk_size" {
+  type = string
+  default = "42000"
+  description = "The initial disk size for VirtualBox builds"
+
 }
 
 variable "disk_cache" {


### PR DESCRIPTION
#### Summary and Scope

Addresses an issue of building VirtualBox locally and the disk size not being large enough for the build. This does not impact the QEMU build process, nor the customer release process.

- Fixes [MTL-1649](https://jira-pro.its.hpecorp.net:8443/browse/MTL-1649)

##### Issue Type

- Bugfix Pull Request

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
