### PR TITLE
Fixing issue with pre csm 1.0 ceph fs pool names and storage classes

### DIFF
--- a/boxes/ncn-node-images/storage-ceph/files/scripts/common/csi-configuration.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/common/csi-configuration.sh
@@ -163,7 +163,7 @@ function create_cephfs_storage_class {
       parameters:
          clusterID: $FSID
          fsName: cephfs
-         pool: cephfs.cephfs.data
+         pool: $(ceph fs ls --format json-pretty|jq -r '.[].data_pools[]')
          csi.storage.k8s.io/provisioner-secret-name: csi-cephfs-secret
          csi.storage.k8s.io/provisioner-secret-namespace: default
          csi.storage.k8s.io/controller-expand-secret-name: csi-cephfs-secret
@@ -368,7 +368,7 @@ function create_cephfs_1.2_storage_class {
       parameters:
          clusterID: $FSID
          fsName: cephfs
-         pool: cephfs.cephfs.data
+         pool: $(ceph fs ls --format json-pretty|jq -r '.[].data_pools[]')
          csi.storage.k8s.io/provisioner-secret-name: csi-cephfs-secret
          csi.storage.k8s.io/provisioner-secret-namespace: default
          csi.storage.k8s.io/controller-expand-secret-name: csi-cephfs-secret


### PR DESCRIPTION
#### Summary and Scope
Installs of 0.9.x have a cephfs pool name of cephfs_data which if the
csi-configuration.sh is re-run accidentally it will cause manifest failures
due to immutable data in the existing storage class.

- Fixes # CASMTRIAGE-3156

##### Issue Type

- Bugfix Pull Request

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
#### Risks and Mitigations
