### PR TITLE
MTL-1660 Add Ansible Virtualenv for CSM

### DIFF
--- a/boxes/ncn-common/common.pkr.hcl
+++ b/boxes/ncn-common/common.pkr.hcl
@@ -110,6 +110,10 @@ build {
   }
 
   provisioner "shell" {
+    script = "${path.root}/provisioners/common/disk_resize.sh"
+  }
+
+  provisioner "shell" {
     inline = [
       "bash -c 'rpm --import https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc'"]
   }
@@ -121,10 +125,6 @@ build {
       "ARTIFACTORY_TOKEN=${var.artifactory_token}"
     ]
     inline = ["bash -c /srv/cray/custom/repos.sh"]
-  }
-
-  provisioner "shell" {
-    script = "${path.root}/provisioners/common/disk_resize.sh"
   }
 
   provisioner "shell" {
@@ -189,6 +189,10 @@ build {
       "qemu.ncn-common",
       "virtualbox-ovf.ncn-common"
     ]
+  }
+
+  provisioner "shell" {
+    script = "${path.root}/provisioners/common/csm/ansible.sh"
   }
 
   provisioner "shell" {

--- a/boxes/ncn-common/provisioners/common/csm/ansible.sh
+++ b/boxes/ncn-common/provisioners/common/csm/ansible.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+ANSIBLE_VERSION=${ANSIBLE_VERSION:-2.11.10}
+REQUIREMENTS=( boto3 netaddr )
+
+echo "Installing CSM Ansible $ANSIBLE_VERSION"
+mkdir -pv /etc/ansible
+pushd /etc/ansible
+pip3 install virtualenv
+virtualenv csm_ansible
+. csm_ansible/bin/activate
+pip3 install ansible-core==$ANSIBLE_VERSION
+pip3 install ansible
+
+echo "Installing requirements: ${REQUIREMENTS[@]}"
+for requirement in ${REQUIREMENTS[@]}; do
+    pip3 install $requirement
+done
+deactivate
+popd

--- a/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/storage-ceph/provisioners/common/install.sh
@@ -9,20 +9,17 @@ mkdir -p /etc/kubernetes
 echo "export KUBECONFIG=\"/etc/kubernetes/admin.conf\"" >> /etc/profile.d/cray.sh
 
 echo "Moving ceph operations files into place"
-mkdir -p /etc/ansible
 mkdir -p /srv/cray/tmp
 mkdir -p /srv/cray/tmp/storage_classes
-mkdir -p /etc/ansible
 
-echo "Creating directory for caching pomdan images"
+echo "Creating directory for caching podman images"
 image_dir="/srv/cray/resources/common/images/"
 mkdir -p $image_dir
 
 mv /srv/cray/resources/common/ansible/* /etc/ansible/
 
-echo "Installing Ansible"
+echo "Installing New Ansible Env"
 pushd /etc/ansible
-pip3 install virtualenv
 virtualenv boto3_ansible
 . boto3_ansible/bin/activate
 pip3 install ansible


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1660
- Relates to MTL-1513

##### Issue Type
<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This moves some of the Ansible init out of storage-ceph and into NCN common.
There is desire to have Ansible everywhere, starting in 1.2.


#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
