### PR TITLE
MTL-1591: Remove kernel debug RPMs

### DIFF
--- a/boxes/ncn-common/common.pkr.hcl
+++ b/boxes/ncn-common/common.pkr.hcl
@@ -146,17 +146,6 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = [
-      "SLES15_KERNEL_VERSION=${var.kernel_version}"
-    ]
-    script = "${path.root}/scripts/kernel-debug.sh"
-    only = [
-      "qemu.ncn-common",
-      "virtualbox-ovf.ncn-common"
-    ]
-  }
-
-  provisioner "shell" {
     script = "${path.root}/provisioners/metal/hpc.sh"
     only = [
       "qemu.ncn-common",

--- a/boxes/ncn-common/scripts/kernel-debug.sh
+++ b/boxes/ncn-common/scripts/kernel-debug.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-KERNEL_PACKAGES=(kernel-default-debuginfo-"$SLES15_KERNEL_VERSION"
-kernel-default-debugsource-"$SLES15_KERNEL_VERSION")
-
-eval zypper --plus-content debug --non-interactive install --no-recommends --oldpackage "${KERNEL_PACKAGES[*]}"


### PR DESCRIPTION
#### Summary and Scope

- Relates to [MTL-1591](https://jira-pro.its.hpecorp.net:8443/browse/MTL-1591)

##### Issue Type
- RFE Pull Request

Removes the install of kernel-default-debuginfo and kernel-default-debugsource. These will be migrated to the `csm` repo. This significantly reduces the size of the images, and also reduces the build time.

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Risks and Mitigations
 
There is a risk that the included RPM does not match the version of the kernel installed. There is an effort to sync these things across all releases.
