### PR TITLE
CASMTRIAGE-3193 fix kdump not working

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 cicd:
   - .github/*
   - .github/**/*
@@ -9,5 +32,4 @@ documentation:
 
 legal:
   - LICENSE
-
 

--- a/boxes/ncn-common/files/scripts/common/create-kdump-artifacts.sh
+++ b/boxes/ncn-common/files/scripts/common/create-kdump-artifacts.sh
@@ -1,5 +1,27 @@
 #!/bin/bash
-# Copyright 2021 HPED LP
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 # create-kdump-artifacts.sh creates an initrd for use with kdump
 #   this specialized initrd is booted when a node crashes
 #   it is specifically designed to work with the persistent overlay and RAIDs in use in Shasta 1.4+
@@ -225,6 +247,13 @@ sed -i 's/^\(ROOTDIR\)=.*$/\1=\"\/kdump\/overlay\"/' lib/kdump/save_dump.sh
 sed -i 's/^\(KDUMP_SAVEDIR\)=.*$/\1=\"file:\/\/\/var\/crash\"/' etc/sysconfig/kdump
 # optionally, uncomment to stay in the initrd after the dump is complete
 #sed -i 's/^\(KDUMP_IMMEDIATE_REBOOT\)=.*$/\1=\"no"/' etc/sysconfig/kdump
+
+# this is a hacky workaround to remove a rogue fstab entry in 1.2+
+# /kdump/mnt0 should be the ROOTRAID, not SQFSRAID
+# it is added by the kdump dracut module, but can be inaccurate if the root label matches the squashfs label
+# prior to this commit, earlier versions of csm will hit this issue,
+# so this can help provide backwards compatibility if kdump needs to be enabled on those environments
+sed -i '/^LABEL=SQFSRAID \/kdump\/mnt0/d' etc/fstab
 
 # Use a here doc to create a simple pre-script that mounts the overlay
 cat << EOF > sbin/mount_kdump_overlay.sh


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

#### Summary and Scope

- Fixes CASMTRIAGE-3193
- CSM 1.3 enhancements https://github.com/Cray-HPE/node-image-build/pull/236 
- Relates to MTL-1616

##### Issue Type

- Bugfix Pull Request

In 1.0.x, there is a `ROOTIMG` entry in the node image's `/etc/fstab`.  This LABEL/mount isn't actually used anywhere except for when the image is built (https://stash.us.cray.com/projects/CASM-ARCHIVE/repos/node-image-sles15-base-archive/browse/http/autoinst.template.xml#126-135) as part of autoyast so it is a bit of a misnomer.

```
ncn-m001:~ # blkid -l -t "LABEL=ROOTIMG" -o device
ncn-m001:~ #
```

When the kdump initrd is generated, the kdump dracut module checks the running system for mount points and tries to convert them to kdump mount points.  Namely, it tries it's best to find `/` and create an entry for it in the kdump initrd at `/kdump/mnt0`.  In 1.0.x, the kdump dracut module has a non-fatal error, which ironically allowed the the script to continue to run.  

```
++ blkid -l -t LABEL=ROOTIMG -o device
+ _dev=
+ kdump_add_host_dev ''
+ local _dev=
+ [[  LABEL=ROOTRAID LABEL=SQFSRAID /kdump/mnt1/LiveOS/filesystem.squashfs #   == *\ \ * ]]
+ return
+ host_fs_types["$_dev"]=ext4
/usr/lib/dracut/modules.d/99kdump/module-setup.sh: line 83: host_fs_types["$_dev"]: bad array subscript
```

Since the `blkid` command does not return a device, the resulting fstab is empty.  In this case, this is what we want.  We explicitly define the kdump mount points when creating the kdump initrd because it needs to do some special things that the default kdump initrd does not work out of the box with: mount the SQFSRAID, mount the BOOTRAID, mount the r/o squash image from the SQFSRAID, and mount the overlay for writing.


In 1.2.x, this label was changed to SQFSRAID (https://github.com/Cray-HPE/node-image-build/blob/develop/boxes/sles15-base/http/autoinst.template.xml#L99-L101).  Since this label actually matches a RAID we setup, it returns a device:

```
ncn-m001:~ # blkid -l -t "LABEL=SQFSRAID" -o device
/dev/md125
```

the dracut kdump module then appends it to the kdump initrd's `fstab`.  In a simple situation where we just have a disk that matches that label, this would be expected and useful behavior.  However, since we have to create a custom initrd to handle the mounting of the overlay, this addition to our expliclty defined `fstab` now becomes a rogue entry.  

```
LABEL=SQFSRAID /kdump/mnt0 ext4 defaults 0 2 <------- this is the rogue entry
LABEL=ROOTRAID /kdump/mnt0/ xfs defaults 0 0
LABEL=SQFSRAID /kdump/mnt1/ xfs defaults 0 0
/kdump/mnt1/LiveOS/filesystem.squashfs /kdump/mnt2 squashfs ro,defaults 0 0
# overlay is mounted via mount_kdump_overlay.sh
```

When kdump loads up, it reads the `fstab` and tries to mount SQFSRAID at `/kdump/mnt0`.  This causes the error seen on the NCNs where it complains about a duplicate mount, which is true.  

```
[FAILED] Failed to mount /kdump/mnt0.
[DEPEND] Dependency failed for Local File Systems.
[ 2254.592928] systemd-fstab-generator[42629]: Failed to create unit file /run/systemd/generator/kdump-mnt0.mount, as it already exists. Duplicate entry in /etc/fstab?
[ 2258.896269] dracut-cmdline[42701]: mv: cannot stat '/etc/multipath.conf.kdump': No such file or directory
[FAILED] Failed to mount /kdump/mnt0.
[DEPEND] Dependency failed for Local File Systems.
[ 2261.998214] systemd-fstab-generator[42838]: Failed to create unit file /run/systemd/generator/kdump-mnt0.mount, as it already exists. Duplicate entry in /etc/fstab?
[FAILED] Failed to mount /k[ 2267.463597] systemd-fstab-generator[42873]: Failed to create unit file /run/systemd/generator/kdump-mnt0.mount, as it already exists. Duplicate entry in /etc/fstab?
```

Even if this wasn't the case, the mount would still fail since it is erronesouly defined as `ext4` instead of it's real file system type, `xfs`.  

Further enhancements and error handling are implemented in: MTL-1685 for csm 1.3

This works around the issue by removing the rogue fstab entry.  Further enhancements will come in a 1.3 PR.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
N/A
 
#### Risks and Mitigations
 
Low.  
