### PR TITLE
CASMINST-4462: don't use xattrs, add script for creating an initrd

### DIFF
--- a/boxes/ncn-common/files/scripts/common/create-ims-initrd.sh
+++ b/boxes/ncn-common/files/scripts/common/create-ims-initrd.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# This script does not use bind mounts and thus executes correctly in a container
+set -e
+set -x
+
+echo "Generating initrd..."
+
+version_full=$(rpm -q --queryformat "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-default)
+version_base=${version_full%%-*}
+version_suse=${version_full##*-}
+version_suse=${version_suse%.*.*}
+version="$version_base-$version_suse-default"
+
+dracut \
+--force \
+--omit 'cifs ntfs-3g btrfs nfs fcoe iscsi modsign fcoe-uefi nbd dmraid multipath dmsquash-live-ntfs' \
+--omit-drivers 'ecb md5 hmac' \
+--add 'mdraid' \
+--force-add 'dmsquash-live livenet mdraid' \
+--kver ${version} \
+--no-hostonly \
+--no-hostonly-cmdline \
+--printsize \
+--xz \
+/boot/initrd-${version}
+
+exit 0

--- a/boxes/ncn-common/files/scripts/common/create-kis-artifacts.sh
+++ b/boxes/ncn-common/files/scripts/common/create-kis-artifacts.sh
@@ -1,5 +1,28 @@
 #!/bin/bash
 
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
 # NOTE: it might seem like these KIS scripts belong in a metal subdir instead of common
 # but the idea is that other environments, cloud ones even may soon IPXE boot squashfs
 # NCNs for the sake of parity.
@@ -43,7 +66,7 @@ fi
 
 if [[ "$1" != "kernel-initrd-only" ]]; then
   echo "Creating squashfs artifact"
-  mksquashfs /mnt/squashfs /squashfs/filesystem.squashfs -comp gzip -no-exports -xattrs -noappend -no-recovery -processors $(nproc) -e /mnt/squashfs/squashfs/filesystem.squashfs
+  mksquashfs /mnt/squashfs /squashfs/filesystem.squashfs -no-xattrs -comp gzip -no-exports -noappend -no-recovery -processors $(nproc) -e /mnt/squashfs/squashfs/filesystem.squashfs
 fi
 
 ( cd /squashfs && tar -cvzf /tmp/kis.tar.gz . )

--- a/boxes/ncn-common/files/scripts/common/create-kis-artifacts.sh
+++ b/boxes/ncn-common/files/scripts/common/create-kis-artifacts.sh
@@ -16,7 +16,6 @@ version_base=${version_full%%-*}
 version_suse=${version_full##*-}
 version_suse=${version_suse%.*.*}
 version="$version_base-$version_suse-default"
-initrd_name="/boot/initrd-$version-dev"
 
 if [[ "$1" != "squashfs-only" ]]; then
   echo "Creating initrd/kernel artifacts"

--- a/boxes/ncn-common/files/scripts/common/create-kis-artifacts.sh
+++ b/boxes/ncn-common/files/scripts/common/create-kis-artifacts.sh
@@ -11,7 +11,7 @@ mount -o bind / /mnt/squashfs
 
 # NOTE: These may be ran on a system; on a PIT or NCN node. Locking the kernel will assist
 #       in chroot envs with newer kernels.
-version_full=$(rpm -q kernel-default | cut -f3- -d'-')
+version_full=$(rpm -q --queryformat "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-default)
 version_base=${version_full%%-*}
 version_suse=${version_full##*-}
 version_suse=${version_suse%.*.*}


### PR DESCRIPTION
#### Summary and Scope

Stop adding xattrs.  They are not needed and cause problems unsquashing
in some contexts (IMS/CFS).

Add a script for creating an initrd that can be used within a container.

- Fixes [CASMINST-4463](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4463)
- Relates to [CASMINST-4462](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4462)

##### Issue Type
<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (redbull)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Testing

- Transferred the initrd/squash/kernel to from algol60 to hela
- Uploaded to IMS
- Customized squash with IMS
- Created a new initrd using the script in this PR
- Saved the resultant squash/initrd/kernel and transferred them to redbull
- Booted redbull w003 with the resultant artifacts