### PR TITLE
Improve kube-api haproxy failover using http instead of tcp check

### DIFF
--- a/boxes/ncn-node-images/k8s/files/scripts/metal/generate_haproxy_cfg.sh
+++ b/boxes/ncn-node-images/k8s/files/scripts/metal/generate_haproxy_cfg.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 function get_ip_from_metadata() {
   host=$1
@@ -52,9 +75,11 @@ frontend k8s-api-nmn
 
 backend k8s-api
     mode tcp
-    option tcp-check
+    option httpchk GET /readyz HTTP/1.0
+    option  log-health-checks
+    http-check expect status 200
     balance roundrobin
-    default-server inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100
+    default-server verify none check-ssl inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100
 "
 
 for x in `seq 5`


### PR DESCRIPTION
#### Summary and Scope

- Fixes https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3263

##### Issue Type

- Bugfix Pull Request

Change kube-api haproxy health check from tcp to http, which makes failover more responsive and doesn't hork up postgres.

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [x] I tested this on craystack (if yes, please include results or a description of the test)

craystack/surtur
```
Apr 27 14:03:30 ncn-m003 haproxy[16498]: [WARNING] 116/140330 (16498) : Health check for server k8s-api/k8s-api-1 failed, reason: Layer4 connection problem, info: "SSL handshake failure (Connection refused)", check duration: 0ms, status: 1/2 UP.
Apr 27 14:03:41 ncn-m003 haproxy[16498]: [WARNING] 116/140341 (16498) : Health check for server k8s-api/k8s-api-1 failed, reason: Layer7 wrong status, code: 403, info: "HTTP status check returned code <3C>403<3E>", check duration: 895ms, status: 0/2 DOWN.
Apr 27 14:03:41 ncn-m003 haproxy[16498]: [WARNING] 116/140341 (16498) : Server k8s-api/k8s-api-1 is DOWN. 2 active and 0 backup servers left. 0 sessions active, 0 requeued, 0 remaining in queue.
Apr 27 14:03:46 ncn-m003 haproxy[16498]: [WARNING] 116/140346 (16498) : Health check for server k8s-api/k8s-api-1 succeeded, reason: Layer7 check passed, code: 200, info: "HTTP status check returned code <3C>200<3E>", check duration: 9ms, status: 1/2 DOWN.
Apr 27 14:03:56 ncn-m003 haproxy[16498]: [WARNING] 116/140356 (16498) : Health check for server k8s-api/k8s-api-1 succeeded, reason: Layer7 check passed, code: 200, info: "HTTP status check returned code <3C>200<3E>", check duration: 6ms, status: 2/2 UP.
Apr 27 14:03:56 ncn-m003 haproxy[16498]: [WARNING] 116/140356 (16498) : Server k8s-api/k8s-api-1 is UP. 3 active and 0 backup servers online. 0 sessions requeued, 0 total in queue.
```
 
#### Idempotency
 
N/A
 
#### Risks and Mitigations
 
Low
