### PR TITLE
MTL-1701 Restore publishing the common layer

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -4,7 +4,7 @@ def promotionToken = ~"(master|main|develop|lts\\/.*)"
 def buildAndPublish = env.TAG_NAME == null && !(env.BRANCH_NAME ==~ promotionToken) ? true : false
 def buildGoogle = true
 def rebuildBaseImage = false
-def rebuildCommonImage = buildAndPublish ? true : false
+def rebuildCommonImage = true
 def sourceBuildVersion = "[RELEASE]" // Pulls the latest release
 
 // Disable pr-merge builds; node-image pipeline doesn't use the PR images at all.
@@ -372,7 +372,6 @@ pipeline {
                         publishCsmImages.release('storage-ceph', GIT_COMMIT[0..6], env.TAG_NAME, GOOGLE_CLOUD_SA_KEY)
                         publishCsmImages.release('kubernetes', GIT_COMMIT[0..6], env.TAG_NAME, GOOGLE_CLOUD_SA_KEY)
                     }
-
                 }
             }
         }


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1701
- Relates to MTL-1668

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

We don't frequently have changes in the base layer, so we limited builds to cease building the base layer through MTL-1668. That code broke the release code, that bug was tracked via MTL-1701. MTL-1701 overzealously ceased publishing the 
common layers, which do frequently have changes. This change ensures those are always published.

Feature Branch Example
<img width="1376" alt="image" src="https://user-images.githubusercontent.com/7772179/165818219-c61477b4-de80-4b98-bb6f-e253b55f5bfb.png">

Git Tag Example (0.3.2-6 was taken on this branch as a test and then deleted)
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/7772179/165818169-cbac329e-326d-4ea5-983d-1b2c896e9d39.png">

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
