### PR TITLE
MTL-1684 - Create python virtual environment for gcp scripts

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -92,138 +92,138 @@ pipeline {
             }
         }
         stage("Build base") {
-			when {
-				expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-				expression { params.rebuildBaseImage  }
-			}
-			steps {
-				withCredentials([
-					string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD')
-				]) {
-					script {
-						def arguments = "-only=qemu.sles15-base -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
-						publishCsmImages.build(arguments, 'boxes/sles15-base/')
-						publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_BASE, VERSION)
-					}
-				}
-			}
+            when {
+                expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
+                expression { params.rebuildBaseImage  }
+            }
+            steps {
+                withCredentials([
+                    string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD')
+                ]) {
+                    script {
+                        def arguments = "-only=qemu.sles15-base -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
+                        publishCsmImages.build(arguments, 'boxes/sles15-base/')
+                        publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_BASE, VERSION)
+                    }
+                }
+            }
         }
-		stage('Upload Base to Artifactory') {
-			when {
-				expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-				expression { params.rebuildBaseImage }
-			}
-			steps {
-				script {
-				    // TODO: Move up to build base step
-					def props = "build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${ISO_URL}"
-					publishCsmImages(pattern: ARTIFACTS_DIRECTORY_BASE, imageName: 'sles15-base', version: env.VERSION, props: props)
-				}
-			}
-		}
+        stage('Upload Base to Artifactory') {
+            when {
+                expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
+                expression { params.rebuildBaseImage }
+            }
+            steps {
+                script {
+                    // TODO: Move up to build base step
+                    def props = "build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${ISO_URL}"
+                    publishCsmImages(pattern: ARTIFACTS_DIRECTORY_BASE, imageName: 'sles15-base', version: env.VERSION, props: props)
+                }
+            }
+        }
         stage("Build Common and upload GCP Base") {
-        	parallel {
-				stage('Upload Base to Google') {
-					when {
-						expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-						expression { params.rebuildBaseImage }
-						expression { params.buildGoogle }
-					}
-					steps {
-						withCredentials([
-							file(credentialsId: 'google-image-manager', variable: 'GOOGLE_CLOUD_SA_KEY')
-						]) {
-							script {
-								sh "./scripts/google/import.sh"
-							}
-						}
-					}
-				}
-        		stage('QEMU Common') {
-					when {
-						expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-						expression { params.rebuildCommonImage }
-					}
-					steps {
-						withCredentials([
-							string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
-							usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
-						]) {
-							script {
-							    // Did we build base? If YES, just use the RC image we built. If NO then use the latest non-RC
-							    def source = "${ARTIFACTS_DIRECTORY_BASE}/sles15-base-${VERSION}.qcow2"
-								if (!params.rebuildBaseImage) {
-								    source = "${STABLE_BASE}/sles15-base/${params.sourceBuildVersion}/sles15-base-${params.sourceBuildVersion}.qcow2"
-								    if (params.sourceBuildVersion != "[RELEASE]") {
-                                        // We must want a different build than latest
-                                        source = nodeImageHelpers.getArtifactorySourceArtifactFromId(source, params.sourceBuildVersion)
-                                    } else {
-
-									}
-								}
-								def arguments = "-only=qemu.ncn-common -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
-								publishCsmImages.build(arguments, 'boxes/ncn-common/')
-								publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_COMMON, VERSION)
-								def props = "build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source}"
-								publishCsmImages(pattern: ARTIFACTS_DIRECTORY_COMMON, imageName: 'ncn-common', version: env.VERSION, props: props)
-							}
-						}
-					}
-				}
-				stage('QEMU PIT Common') {
-					when {
-						expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-						expression { params.rebuildCommonImage }
-					}
-					steps {
-						withCredentials([
-							string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
-							usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
-						]) {
-							script {
-								// Did we build base? If YES, just use the RC image we built. If NO then use the latest non-RC
-							    def source = "${ARTIFACTS_DIRECTORY_BASE}/sles15-base-${VERSION}.qcow2"
-								if (!params.rebuildBaseImage) {
-								    source = "${STABLE_BASE}/sles15-base/${params.sourceBuildVersion}/sles15-base-${params.sourceBuildVersion}.qcow2"
-								    if (params.sourceBuildVersion != "[RELEASE]") {
-                                        // We must want a different build than latest
-                                        source = nodeImageHelpers.getArtifactorySourceArtifactFromId(source, params.sourceBuildVersion)
-                                    } else {
-
-									}
-								}
-								def arguments = "-only=qemu.pit-common -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
-								publishCsmImages.build(arguments, 'boxes/pit-common/')
-								publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_PIT, VERSION)
-								def props = "build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source}"
-								publishCsmImages(pattern: ARTIFACTS_DIRECTORY_PIT, imageName: 'pit-common', version: env.VERSION, props: props)
-							}
-						}
-					}
-				}
-			}
-		}
-		stage("Build GCP Common and PIT") {
             parallel {
-        		stage('GCP Common') {
-					when {
-						expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-						expression { params.rebuildCommonImage }
-						expression { params.buildGoogle }
-					}
-					steps {
-						withCredentials([
-							string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
-							usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN'),
-							file(credentialsId: 'google-image-manager', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
-							file(credentialsId: 'google-image-manager', variable: 'GOOGLE_CLOUD_SA_KEY')
-						]) {
-							script {
-								// Did we build base? If YES, just use the RC image we built. If NO then use the latest non-RC
-								def googleSourceArtifact = "vshasta-sles15-base-${VERSION}"
-								def googleSourceImageFamily = "vshasta-sles15-base"
-								if (!params.rebuildBaseImage) {
-								    if (params.sourceBuildVersion != "[RELEASE]") {
+                stage('Upload Base to Google') {
+                    when {
+                        expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
+                        expression { params.rebuildBaseImage }
+                        expression { params.buildGoogle }
+                    }
+                    steps {
+                        withCredentials([
+                            file(credentialsId: 'google-image-manager', variable: 'GOOGLE_CLOUD_SA_KEY')
+                        ]) {
+                            script {
+                                sh "./scripts/google/import.sh"
+                            }
+                        }
+                    }
+                }
+                stage('QEMU Common') {
+                    when {
+                        expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
+                        expression { params.rebuildCommonImage }
+                    }
+                    steps {
+                        withCredentials([
+                            string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
+                            usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
+                        ]) {
+                            script {
+                                // Did we build base? If YES, just use the RC image we built. If NO then use the latest non-RC
+                                def source = "${ARTIFACTS_DIRECTORY_BASE}/sles15-base-${VERSION}.qcow2"
+                                if (!params.rebuildBaseImage) {
+                                    source = "${STABLE_BASE}/sles15-base/${params.sourceBuildVersion}/sles15-base-${params.sourceBuildVersion}.qcow2"
+                                    if (params.sourceBuildVersion != "[RELEASE]") {
+                                        // We must want a different build than latest
+                                        source = nodeImageHelpers.getArtifactorySourceArtifactFromId(source, params.sourceBuildVersion)
+                                    } else {
+
+                                    }
+                                }
+                                def arguments = "-only=qemu.ncn-common -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
+                                publishCsmImages.build(arguments, 'boxes/ncn-common/')
+                                publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_COMMON, VERSION)
+                                def props = "build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source}"
+                                publishCsmImages(pattern: ARTIFACTS_DIRECTORY_COMMON, imageName: 'ncn-common', version: env.VERSION, props: props)
+                            }
+                        }
+                    }
+                }
+                stage('QEMU PIT Common') {
+                    when {
+                        expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
+                        expression { params.rebuildCommonImage }
+                    }
+                    steps {
+                        withCredentials([
+                            string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
+                            usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
+                        ]) {
+                            script {
+                                // Did we build base? If YES, just use the RC image we built. If NO then use the latest non-RC
+                                def source = "${ARTIFACTS_DIRECTORY_BASE}/sles15-base-${VERSION}.qcow2"
+                                if (!params.rebuildBaseImage) {
+                                    source = "${STABLE_BASE}/sles15-base/${params.sourceBuildVersion}/sles15-base-${params.sourceBuildVersion}.qcow2"
+                                    if (params.sourceBuildVersion != "[RELEASE]") {
+                                        // We must want a different build than latest
+                                        source = nodeImageHelpers.getArtifactorySourceArtifactFromId(source, params.sourceBuildVersion)
+                                    } else {
+
+                                    }
+                                }
+                                def arguments = "-only=qemu.pit-common -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
+                                publishCsmImages.build(arguments, 'boxes/pit-common/')
+                                publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_PIT, VERSION)
+                                def props = "build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source}"
+                                publishCsmImages(pattern: ARTIFACTS_DIRECTORY_PIT, imageName: 'pit-common', version: env.VERSION, props: props)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage("Build GCP Common and PIT") {
+            parallel {
+                stage('GCP Common') {
+                    when {
+                        expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
+                        expression { params.rebuildCommonImage }
+                        expression { params.buildGoogle }
+                    }
+                    steps {
+                        withCredentials([
+                            string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
+                            usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN'),
+                            file(credentialsId: 'google-image-manager', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
+                            file(credentialsId: 'google-image-manager', variable: 'GOOGLE_CLOUD_SA_KEY')
+                        ]) {
+                            script {
+                                // Did we build base? If YES, just use the RC image we built. If NO then use the latest non-RC
+                                def googleSourceArtifact = "vshasta-sles15-base-${VERSION}"
+                                def googleSourceImageFamily = "vshasta-sles15-base"
+                                if (!params.rebuildBaseImage) {
+                                    if (params.sourceBuildVersion != "[RELEASE]") {
                                         // We must want a different build than latest
                                         googleSourceArtifact = nodeImageHelpers.getGoogleCloudSourceArtifactFromId(googleSourceImageFamily, params.sourceBuildVersion)
                                     } else {
@@ -232,34 +232,34 @@ pipeline {
                                             googleCloudProject: params.googleSourceImageProjectId,
                                             googleCloudFamily: googleSourceImageFamily
                                         )
-									}
-								}
+                                    }
+                                }
 
-								def googleArguments = "-only=googlecompute.ncn-common -var 'google_source_image_name=${googleSourceArtifact}' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'artifact_version=${VERSION}'"
-								publishCsmImages.build(googleArguments, 'boxes/ncn-common/')
-							}
-						}
-					}
-				}
-				stage('GCP PIT Common') {
-					when {
-						expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-						expression { params.rebuildCommonImage }
-						expression { params.buildGoogle }
-					}
-					steps {
-						withCredentials([
-							string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
-							usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN'),
-							file(credentialsId: 'google-image-manager', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
-							file(credentialsId: 'google-image-manager', variable: 'GOOGLE_CLOUD_SA_KEY')
-						]) {
-							script {
-								// Did we build base? If YES, just use the RC image we built. If NO then use the latest non-RC
-								def googleSourceArtifact = "vshasta-sles15-base-${VERSION}"
-								googleSourceImageFamily = "vshasta-sles15-base"
-								if (!params.rebuildBaseImage) {
-								    if (params.sourceBuildVersion != "[RELEASE]") {
+                                def googleArguments = "-only=googlecompute.ncn-common -var 'google_source_image_name=${googleSourceArtifact}' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'artifact_version=${VERSION}'"
+                                publishCsmImages.build(googleArguments, 'boxes/ncn-common/')
+                            }
+                        }
+                    }
+                }
+                stage('GCP PIT Common') {
+                    when {
+                        expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
+                        expression { params.rebuildCommonImage }
+                        expression { params.buildGoogle }
+                    }
+                    steps {
+                        withCredentials([
+                            string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
+                            usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN'),
+                            file(credentialsId: 'google-image-manager', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
+                            file(credentialsId: 'google-image-manager', variable: 'GOOGLE_CLOUD_SA_KEY')
+                        ]) {
+                            script {
+                                // Did we build base? If YES, just use the RC image we built. If NO then use the latest non-RC
+                                def googleSourceArtifact = "vshasta-sles15-base-${VERSION}"
+                                googleSourceImageFamily = "vshasta-sles15-base"
+                                if (!params.rebuildBaseImage) {
+                                    if (params.sourceBuildVersion != "[RELEASE]") {
                                         // We must want a different build than latest
                                         googleSourceArtifact = nodeImageHelpers.getGoogleCloudSourceArtifactFromId(googleSourceImageFamily, params.sourceBuildVersion)
                                     } else {
@@ -268,15 +268,15 @@ pipeline {
                                             googleCloudProject: params.googleSourceImageProjectId,
                                             googleCloudFamily: googleSourceImageFamily
                                         )
-									}
-								}
+                                    }
+                                }
 
-								def googleArguments = "-only=googlecompute.pit-common -var 'google_source_image_name=${googleSourceArtifact}' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'artifact_version=${VERSION}'"
-								publishCsmImages.build(googleArguments, 'boxes/pit-common/')
-							}
-						}
-					}
-				}
+                                def googleArguments = "-only=googlecompute.pit-common -var 'google_source_image_name=${googleSourceArtifact}' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'artifact_version=${VERSION}'"
+                                publishCsmImages.build(googleArguments, 'boxes/pit-common/')
+                            }
+                        }
+                    }
+                }
             }
         }
         // Always build.
@@ -294,17 +294,17 @@ pipeline {
                             usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
                         ]) {
                             script {
-								// Did we build common? If YES, just use the RC image we built. If NO then use the latest non-RC
-							    def source = "${ARTIFACTS_DIRECTORY_COMMON}/ncn-common-${VERSION}.qcow2"
-								if (!params.rebuildCommonImage) {
-								    source = "${STABLE_BASE}/ncn-common/${params.sourceBuildVersion}/ncn-common-${params.sourceBuildVersion}.qcow2"
-								    if (params.sourceBuildVersion != "[RELEASE]") {
+                                // Did we build common? If YES, just use the RC image we built. If NO then use the latest non-RC
+                                def source = "${ARTIFACTS_DIRECTORY_COMMON}/ncn-common-${VERSION}.qcow2"
+                                if (!params.rebuildCommonImage) {
+                                    source = "${STABLE_BASE}/ncn-common/${params.sourceBuildVersion}/ncn-common-${params.sourceBuildVersion}.qcow2"
+                                    if (params.sourceBuildVersion != "[RELEASE]") {
                                         // We must want a different build than latest
                                         source = nodeImageHelpers.getArtifactorySourceArtifactFromId(source, params.sourceBuildVersion)
                                     } else {
 
-									}
-								}
+                                    }
+                                }
                                 def arguments = "-only=qemu.* -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
                                 publishCsmImages.build(arguments, 'boxes/ncn-node-images/')
                                 publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_K8S, env.VERSION)
@@ -330,10 +330,10 @@ pipeline {
                         ]) {
                             script {
                                 // Did we build base? If YES, just use the RC image we built. If NO then use the latest non-RC
-								def googleSourceArtifact = "vshasta-ncn-common-${VERSION}"
-								def googleSourceImageFamily = "vshasta-ncn-common"
-								if (!params.rebuildCommonImage) {
-								    if (params.sourceBuildVersion != "[RELEASE]") {
+                                def googleSourceArtifact = "vshasta-ncn-common-${VERSION}"
+                                def googleSourceImageFamily = "vshasta-ncn-common"
+                                if (!params.rebuildCommonImage) {
+                                    if (params.sourceBuildVersion != "[RELEASE]") {
                                         // We must want a different build than latest
                                         googleSourceArtifact = nodeImageHelpers.getGoogleCloudSourceArtifactFromId(googleSourceImageFamily, params.sourceBuildVersion)
                                     } else {
@@ -342,8 +342,8 @@ pipeline {
                                             googleCloudProject: params.googleSourceImageProjectId,
                                             googleCloudFamily: googleSourceImageFamily
                                         )
-									}
-								}
+                                    }
+                                }
 
                                 def googleArguments = "-only=googlecompute.* -var 'google_source_image_name=${googleSourceArtifact}' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'artifact_version=${VERSION}'"
                                 publishCsmImages.build(googleArguments, 'boxes/ncn-node-images/')
@@ -374,6 +374,23 @@ pipeline {
                     }
                 }
             }
+        }
+    }
+    post {
+        always {
+            echo 'I hope you have a nice day!'
+        }
+        success {
+            echo 'The build was: success'
+        }
+        unstable {
+            echo 'The build was: unstable'
+        }
+        failure {
+            echo 'The build was: failure'
+        }
+        changed {
+            echo 'The build was: changed'
         }
     }
 }

--- a/boxes/ncn-common/common.pkr.hcl
+++ b/boxes/ncn-common/common.pkr.hcl
@@ -192,6 +192,10 @@ build {
   }
 
   provisioner "shell" {
+    script = "${path.root}/provisioners/google/pyenv.sh"
+  }
+
+  provisioner "shell" {
     script = "${path.root}/provisioners/metal/fstab.sh"
     only = [
       "qemu.ncn-common",

--- a/boxes/ncn-common/files/scripts/google/cloudinit.sh
+++ b/boxes/ncn-common/files/scripts/google/cloudinit.sh
@@ -3,10 +3,10 @@
 set -e
 
 echo "Scheduling local DNS server(s) awareness updates for every 5 minutes"
-echo "*/5 * * * * root . /etc/profile.d/cray.sh; /usr/bin/python3 /srv/cray/scripts/google/update-dns.py >> /var/log/cray/cron.log 2>&1" > /etc/cron.d/cray-update-dns
+echo "*/5 * * * * root . /etc/profile.d/cray.sh; /etc/ansible/csm_gcp/bin/python3 /srv/cray/scripts/google/update-dns.py >> /var/log/cray/cron.log 2>&1" > /etc/cron.d/cray-update-dns
 
 echo "Running initial local DNS server(s) awareness update"
-while ! /usr/bin/python3 /srv/cray/scripts/google/update-dns.py; do
+while ! /etc/ansible/csm_gcp/bin/python3 /srv/cray/scripts/google/update-dns.py; do
   sleep 5
 done
 systemctl restart cron

--- a/boxes/ncn-common/files/scripts/google/update-dns.py
+++ b/boxes/ncn-common/files/scripts/google/update-dns.py
@@ -1,10 +1,27 @@
-"""
-Updates the dns configuration for a node based on expected Virtual Shasta project/nodes config
+#  MIT License
+#
+#  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
 
-Copyright 2019, Cray Inc. All rights reserved.
-"""
+# Updates the dns configuration for a node based on expected Virtual Shasta project/nodes config
 
-import requests
 import re
 import hashlib
 import os

--- a/boxes/ncn-common/files/utilities/common/craysys/craygoogle.py
+++ b/boxes/ncn-common/files/utilities/common/craysys/craygoogle.py
@@ -1,6 +1,29 @@
+#  MIT License
+#
+#  (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+
 import requests
 import sys
 import json
+
 
 class CrayGoogle:
 

--- a/boxes/ncn-common/provisioners/google/pyenv.sh
+++ b/boxes/ncn-common/provisioners/google/pyenv.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -e
+
+# TODO: MTL-1513 - convert to ansible configuration
+REQUIREMENTS=( requests )
+
+echo "Installing Python requirements for GCP scripts"
+pushd /etc/ansible
+virtualenv csm_gcp
+. csm_gcp/bin/activate
+
+echo "Installing requirements: ${REQUIREMENTS[@]}"
+for requirement in "${REQUIREMENTS[@]}"; do
+    pip3 install "$requirement"
+done
+deactivate
+popd

--- a/boxes/pit-common/files/scripts/google/update-dns.py
+++ b/boxes/pit-common/files/scripts/google/update-dns.py
@@ -1,10 +1,27 @@
-"""
-Updates the dns configuration for a node based on expected Virtual Shasta project/nodes config
+#  MIT License
+#
+#  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
 
-Copyright 2019, Cray Inc. All rights reserved.
-"""
+# Updates the dns configuration for a node based on expected Virtual Shasta project/nodes config
 
-import requests
 import re
 import hashlib
 import os


### PR DESCRIPTION
#### Summary and Scope

- Fixes [MTL-1684](https://jira-pro.its.hpecorp.net:8443/browse/MTL-1684)

##### Issue Type

- RFE Pull Request

Previously `requests` was being installed with the system python. This was removed. A new virtual environment was added specifically for scripts executed in the GCP environment that needed the installation of requests. 

This will later be amended by [MTL-1673](https://jira-pro.its.hpecorp.net:8443/browse/MTL-1673) when a standard is established for adding and using virtual environments with Ansible. This PR just finishes the work started in [MTL-1668](https://jira-pro.its.hpecorp.net:8443/browse/MTL-1668)

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
