### PR TITLE
MTL-1702 Allow git vendor updates

### DIFF
--- a/.github/workflows/merge-strategy.yml
+++ b/.github/workflows/merge-strategy.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Block Merge Commits
-        uses: Morishiri/block-merge-commits-action@v1.0.1
+        uses: 4lambda/block-merge-commits-action@v1.0.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1702

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Since `git vendor` updates create a merge commit, they currently can't be merged due to the existing merge commit blocker.

This adopts a different plugin that will allow us to gate merge commits while allowing `git vendor` updates. 

Example of a merge commit existing and causing a failure:
https://github.com/Cray-HPE/node-image-build/runs/6231047253?check_suite_focus=true
```
[610]rusty@C02F43JEMD6P:~/gitstuffs/cray-shasta/node-image-build> git merge origin/MTL-1684
Merge made by the 'recursive' strategy.
 Jenkinsfile.github                                            | 355 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++------------------------------------------------------------
 boxes/ncn-common/common.pkr.hcl                               |   4 ++
 boxes/ncn-common/files/scripts/google/cloudinit.sh            |   4 +-
 boxes/ncn-common/files/scripts/google/update-dns.py           |  27 +++++++---
 boxes/ncn-common/files/utilities/common/craysys/craygoogle.py |  23 +++++++++
 boxes/ncn-common/provisioners/google/pyenv.sh                 |  41 +++++++++++++++
 6 files changed, 277 insertions(+), 177 deletions(-)
 create mode 100644 boxes/ncn-common/provisioners/google/pyenv.sh
[611]rusty@C02F43JEMD6P:~/gitstuffs/cray-shasta/node-image-build> git push
Enumerating objects: 52, done.
Counting objects: 100% (37/37), done.
Delta compression using up to 12 threads
Compressing objects: 100% (18/18), done.
Writing objects: 100% (20/20), 4.81 KiB | 351.00 KiB/s, done.
Total 20 (delta 10), reused 0 (delta 0)
remote: Resolving deltas: 100% (10/10), completed with 8 local objects.
To github.com:Cray-HPE/node-image-build.git
   c5a230403..ba9724736  MTL-1702-allow-git-vendor -> MTL-1702-allow-git-vendor
```


Example of a merge commit from csm-rpms existing, and no other merge commits existing:
https://github.com/Cray-HPE/node-image-build/runs/6231092573?check_suite_focus=true
```
commit cd95820ad6e43bc8d4ad81311d9060dab738e039 (HEAD -> MTL-1702-allow-git-vendor, origin/MTL-1702-allow-git-vendor)
Author: rustydb <doomslayer@hpe.com>
Date:   Fri Apr 29 10:31:27 2022 -0500

    Squashed 'vendor/github.com/Cray-HPE/csm-rpms/' changes from 4c172ed78..2c523815d

    2c523815d CASMINST-4471 fix for making sure basecamp and nexus startup
    5c11ed8ca casmpet-5560: specify first field returned to correct 13h not found error
    80b5bec70 Podman updates / reattempt
    e407a236c CASMINST-4485 Minor update for handling /usr/bin/yq

    git-subtree-dir: vendor/github.com/Cray-HPE/csm-rpms
    git-subtree-split: 2c523815dc31aa6fd84cdfc1ec3141243dfd443e

commit c6540d67cb957cf2e87386ffa184b31fbdfe4964
Author: rustydb <doomslayer@hpe.com>
Date:   Thu Apr 28 10:37:59 2022 -0500

    MTL-1702 Allow git vendor updates
```
#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
