### PR TITLE
Allow slashes on the vendor dir

### DIFF
--- a/.github/workflows/merge-strategy.yml
+++ b/.github/workflows/merge-strategy.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Block Merge Commits
-        uses: 4lambda/block-merge-commits-action@v1.0.2
+        uses: 4lambda/block-merge-commits-action@v1.0.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Fixes csm-rpms updates if they contain multiple changed files.

The issue was that the plugin we used had the `/g` flag on the regex, which remembers the previous matched index. This caused the regex to flip between true and false undesirably.