### PR TITLE
Fix common tests

### DIFF
--- a/boxes/ncn-common/common.pkr.hcl
+++ b/boxes/ncn-common/common.pkr.hcl
@@ -250,14 +250,9 @@ build {
     only = ["qemu.ncn-common"]
   }
 
-  // FIXME: These should run for ALL sources; verify these work correctly with Google.
   provisioner "shell" {
     inline = [
       "bash -c 'goss -g /srv/cray/tests/common/goss-image-common.yaml validate -f junit | tee /tmp/goss_out.xml'"]
-    only = [
-      "qemu.ncn-common",
-      "virtualbox-ovf.ncn-common"
-    ]
   }
 
   provisioner "shell" {

--- a/boxes/ncn-common/common.pkr.hcl
+++ b/boxes/ncn-common/common.pkr.hcl
@@ -250,6 +250,7 @@ build {
     only = ["qemu.ncn-common"]
   }
 
+  // FIXME: These should run for ALL sources; verify these work correctly with Google.
   provisioner "shell" {
     inline = [
       "bash -c 'goss -g /srv/cray/tests/common/goss-image-common.yaml validate -f junit | tee /tmp/goss_out.xml'"]
@@ -259,7 +260,6 @@ build {
     ]
   }
 
-  // FIXME: These should run for ALL sources; verify these work correctly with Google.
   provisioner "shell" {
     inline = [
       "bash -c 'goss -g /srv/cray/tests/metal/goss-image-common.yaml validate -f junit | tee /tmp/goss_metal_out.xml'"]


### PR DESCRIPTION
This enables the common tests for all source types.

Right now common tests are only running for metal, but since they're _common_ they need to run for everything.