### PR TITLE
CASMTRIAGE-3326 add prefer to chrony config, update template

### DIFF
--- a/boxes/ncn-common/files/scripts/common/chrony/templates/cray.conf.j2
+++ b/boxes/ncn-common/files/scripts/common/chrony/templates/cray.conf.j2
@@ -9,17 +9,14 @@ pool {{ pool }} iburst
 {% endif %}
 {% endfor %}
 {% for server in servers | sort -%}
-{% if local_hostname == 'ncn-m001' %}
-{% if server == 'ncn-m001' %}
+{% if local_hostname == 'ncn-m001' and server == 'ncn-m001' %}
 # server {{ server }} will not be used as itself for a server
 {% else %}
-server {{ server }} iburst trust
+server {{ server }} iburst trust prefer
 initstepslew 1 {{ server }}
 {% endif %}
-{% else %}
-{% if server == 'ncn-m001' %}
-server {{ server }} iburst trust
-{% endif %}
+{% if local_hostname != 'ncn-m001' and server != 'ncn-m001' %}
+# {{ local_hostname }}
 {% endif %}
 {% endfor %}
 {% for peer in peers | sort -%}


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes CASMTRIAGE-3336

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

This restores the template to what we had been using.  It was slightly modified when we transitioned to this script.  It was missing the `initstepslew` directive.  I also added `prefer` as it allowed the nodes to quiesce much faster when rapidly changing configurations.


#### Testing

- `#redbull`

I booted the nodes and ran through the documented procedure.

```
redbull-ncn-m001-pit:/var/www/ncn-w003 # for i in $(grep -oP 'ncn-\w\d+' /etc/dnsmasq.d/statics.conf | sort -u | grep -v ncn-m001); do ssh $i "chronyc waitsync 6 0.5 0.5 10"; done
Warning: Permanently added 'ncn-m002,10.252.1.5' (ECDSA) to the list of known hosts.
try: 1, refid: 0AFC0104, correction: 0.000010350, skew: 0.577
try: 2, refid: 0AFC0104, correction: 0.000008899, skew: 0.577
try: 3, refid: 0AFC0104, correction: 0.000007449, skew: 0.577
try: 4, refid: 0AFC0104, correction: 0.000005998, skew: 0.577
try: 5, refid: 0AFC0104, correction: 0.000004548, skew: 0.577
try: 6, refid: 0AFC0104, correction: 0.000019750, skew: 0.221
Warning: Permanently added 'ncn-m003,10.252.1.6' (ECDSA) to the list of known hosts.
try: 1, refid: 0AFC0104, correction: 0.000006769, skew: 0.529
try: 2, refid: 0AFC0104, correction: 0.000006340, skew: 0.529
try: 3, refid: 0AFC0104, correction: 0.000005911, skew: 0.529
try: 4, refid: 0AFC0104, correction: 0.000005481, skew: 0.529
try: 5, refid: 0AFC0104, correction: 0.000005052, skew: 0.529
try: 6, refid: 0AFC0104, correction: 0.000008126, skew: 0.429
Warning: Permanently added 'ncn-s001,10.252.1.9' (ECDSA) to the list of known hosts.
try: 1, refid: 0AFC0104, correction: 0.000007482, skew: 0.703
try: 2, refid: 0AFC0104, correction: 0.000007225, skew: 0.703
try: 3, refid: 0AFC0104, correction: 0.000006968, skew: 0.703
try: 4, refid: 0AFC0104, correction: 0.000006711, skew: 0.703
try: 5, refid: 0AFC0104, correction: 0.000006454, skew: 0.703
try: 6, refid: 0AFC0104, correction: 0.000000021, skew: 0.031
Warning: Permanently added 'ncn-s002,10.252.1.10' (ECDSA) to the list of known hosts.
try: 1, refid: 0AFC0104, correction: 0.000014468, skew: 0.129
Warning: Permanently added 'ncn-s003,10.252.1.11' (ECDSA) to the list of known hosts.
try: 1, refid: 0AFC0104, correction: 0.000004576, skew: 0.153
Warning: Permanently added 'ncn-s004,10.252.1.13' (ECDSA) to the list of known hosts.
try: 1, refid: 0AFC0104, correction: 0.000009983, skew: 0.256
Warning: Permanently added 'ncn-w001,10.252.1.7' (ECDSA) to the list of known hosts.
try: 1, refid: 0AFC0104, correction: 0.000010898, skew: 0.642
try: 2, refid: 0AFC0104, correction: 0.000006998, skew: 0.642
try: 3, refid: 0AFC0104, correction: 0.000003099, skew: 0.642
try: 4, refid: 0AFC0104, correction: 0.000000018, skew: 0.057
Warning: Permanently added 'ncn-w002,10.252.1.8' (ECDSA) to the list of known hosts.
try: 1, refid: 0AFC0104, correction: 0.000001596, skew: 0.094
Warning: Permanently added 'ncn-w003,10.252.1.12' (ECDSA) to the list of known hosts.
try: 1, refid: 0AFC0104, correction: 0.000003040, skew: 0.127
```
#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
