### PR TITLE
CASMNET-1549: Add sshd_config cloud-init step and template

### DIFF
--- a/boxes/ncn-common/files/resources/common/cloud/templates/sshd_config.tmpl
+++ b/boxes/ncn-common/files/resources/common/cloud/templates/sshd_config.tmpl
@@ -1,0 +1,25 @@
+## template:jinja
+# Cloud-init has written this file with configuration data
+# that it has been provided. Cloud-init, by default, will write this file
+# a single time (PER_ONCE).
+# Default SUSE/sshd_config with all empty-lines and default comments removed.
+AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+AcceptEnv LC_IDENTIFICATION LC_ALL
+AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+AuthorizedKeysFile .ssh/authorized_keys
+PermitRootLogin yes
+Subsystem sftp /usr/lib/ssh/sftp-server
+UsePAM yes
+X11Forwarding yes
+
+# NCN Additions:
+AcceptEnv IPMITOOL_PASSWORD
+
+# IP Address Limits
+{% for name, network in ds.meta_data.ipam.items() %}
+{% if name != 'chn' and name != 'can' %}
+# Allow access on {{ name }}0 network
+{% set ip_list = network.ip.split('/') %}
+ListenAddress {{ ip_list[0] }}
+{% endif -%}
+{% endfor %}

--- a/boxes/ncn-common/files/scripts/metal/net-init.sh
+++ b/boxes/ncn-common/files/scripts/metal/net-init.sh
@@ -143,4 +143,19 @@ if check_ips 1 ; then
 else
     printf 'net-init: [ % -20s ]\n' 'testing: IPs exist'
 fi
+
+function sshd_config() {
+    if [[ -f /etc/ssh/sshd_config ]]; then
+        rm /etc/ssh/sshd_config
+    fi
+
+    # Render the template
+    printf 'net-init: [ % -20s ]\n' 'running: sshd_config'
+    cloud-init query --format="$(cat /etc/cloud/templates/sshd_config.tmpl)" >/etc/ssh/sshd_config || fail_and_die "cloud-init query failed to render sshd_config.tmpl"
+
+    printf 'net-init: [ % -20s ]\n' 'running: sshd reload'
+    systemctl reload sshd
+}
+sshd_config
+
 printf 'net-init: [ % -20s ]\n' 'completed'


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes [CASMNET-1549](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1549)

##### Issue Type

- Bugfix Pull Request

Allows access to sshd on any network that is not CHN and CAN.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
