### PR TITLE
MTL-1703 Copy cloud-init files into place

### DIFF
--- a/boxes/ncn-node-images/provisioners/metal/install.sh
+++ b/boxes/ncn-node-images/provisioners/metal/install.sh
@@ -31,5 +31,10 @@ echo "Loading in sysctl settings; activating for build-time"
 cp -pvr /srv/cray/sysctl/metal/* /etc/sysctl.d/
 sysctl -p
 
+# Adding cloud-init.cfg files and templates for metal.
+# Do not delete anything there, incase a lower layer already added common configs.
+[ -f /etc/cloud/cloud.cfg ] || cp -pv /srv/cray/resources/common/cloud.cfg /etc/cloud/
+rsync -av /srv/cray/resources/metal/cloud.cfg.d/ /etc/cloud/cloud.cfg.d/
+
 # enable this to run on first boot during deployment, and then the kdump script disables it
 systemctl enable kdump-cray


### PR DESCRIPTION
This amends work for commit a7fcb19f2a1c6c2533e9af17cc0053a05f9c064a.

We're having smoke test failures since MTL-1703 went in, this fixes the issue.

0.3.3-3 worked in vshasta and metal, 0.3.3-4 failed on metal but worked in vshasta. MTL-1703 went into 0.3.3-4.