### PR TITLE
CASMNET-1549: Add iptables rules and service for ssh

### DIFF
--- a/boxes/ncn-common/files/resources/common/cloud/templates/metal-iptables.conf.tmpl
+++ b/boxes/ncn-common/files/resources/common/cloud/templates/metal-iptables.conf.tmpl
@@ -1,0 +1,11 @@
+*filter
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+{% for name, network in ds.meta_data.ipam.items() %}
+{% if name == 'chn' or name == 'can' %}
+{% set ip_list = network.ip.split('/') %}
+-A INPUT -d {{ ip_list[0] }} -p tcp -m tcp --dport 22 -j DROP
+{% endif -%}
+{% endfor %}
+COMMIT

--- a/boxes/ncn-common/files/resources/metal/sshd_config
+++ b/boxes/ncn-common/files/resources/metal/sshd_config
@@ -1,4 +1,5 @@
 # Default SUSE/sshd_config with all empty-lines and comments (asides this ones) removed.
+# SSH access is filtered on CAN/CHN networks by iptables
 AcceptEnv 			LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
 AcceptEnv 			LC_IDENTIFICATION LC_ALL
 AcceptEnv 			LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT

--- a/boxes/ncn-common/files/resources/metal/systemd/metal-iptables.service
+++ b/boxes/ncn-common/files/resources/metal/systemd/metal-iptables.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Loads Metal iptables config
+After=local-fs.target network.service
+
+[Service]
+Type=oneshot
+ExecStart=iptables-restore /etc/iptables/metal.conf
+Restart=no
+RemainAfterExit=no
+
+[Install]
+WantedBy=multi-user.target

--- a/boxes/ncn-common/files/scripts/metal/net-init.sh
+++ b/boxes/ncn-common/files/scripts/metal/net-init.sh
@@ -143,4 +143,21 @@ if check_ips 1 ; then
 else
     printf 'net-init: [ % -20s ]\n' 'testing: IPs exist'
 fi
+
+function iptables_config() {
+    mkdir -p /etc/iptables/
+
+    if [[ -f /etc/iptables/metal.conf ]]; then
+       rm /etc/iptables/metal.conf
+    fi
+
+    # Render the template
+    printf 'net-init: [ % -20s ]\n' 'running: iptables_config'
+    cloud-init query --format="$(cat /etc/cloud/templates/metal-iptables.conf.tmpl)" >/etc/iptables/metal.conf || fail_and_die "cloud-init query failed to render metal-iptables.conf.tmpl"
+
+    printf 'net-init: [ % -20s ]\n' 'running: metal-iptables restart'
+    systemctl restart metal-iptables
+}
+iptables_config
+
 printf 'net-init: [ % -20s ]\n' 'completed'

--- a/boxes/ncn-common/provisioners/metal/setup.sh
+++ b/boxes/ncn-common/provisioners/metal/setup.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 set -e
 
@@ -9,6 +32,7 @@ cp -vp /srv/cray/sysctl/metal/* /etc/sysctl.d/
 cp -pv /srv/cray/resources/metal/systemd/* /usr/lib/systemd/system/
 systemctl enable kdump-cray
 systemctl enable cloud-init-oneshot
+systemctl enable metal-iptables
 
 # Adding sshd_config for metal.
 cp -vp /srv/cray/resources/metal/sshd_config /etc/ssh/sshd_config


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes [CASMNET-1549](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1549)
- Fixes [CASMNET-1568](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1568)

When the NCN is built,  the service is placed on the machine and enabled. The NCN boots, cloud-init kicks off net-init and the iptables_config function puts the iptables file into place, based on the BSS metadata for the networks. This template blocks on CAN and CHN networks. After cloud-init is done, the system finishes booting and the service is executed, which loads the iptables rules that work and allow 22 traffic destined for k8s. 

##### Issue Type

- Bugfix Pull Request

#### Testing

This was tested on Redbull and Mug.

Mug: The rules were loaded on all worker nodes and access was verified for UAI. We confirmed that ssh to the interface's IP was not allowed, but ssh traffic over the interface with a destination of a services within k8s was allowed.
Redbull: The images were booted and it was verified that the config files were properly generated. The service was properly initiated. And the rules were properly applied based on the available networks. It was then further verified that one cannot ssh to an NCN over the blocked network, but ssh access over the other networks is fine.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
