### PR TITLE
Fixing image path for ceph prometheus container to fix goss test

### DIFF
--- a/boxes/ncn-node-images/storage-ceph/files/scripts/common/pre-load-images.sh
+++ b/boxes/ncn-node-images/storage-ceph/files/scripts/common/pre-load-images.sh
@@ -16,6 +16,7 @@ podman tag  registry.local/ceph/ceph:v15.2.15 registry.local/artifactory.algol60
 podman image load -i /srv/cray/resources/common/images/ceph-grafana_6.6.2.tar
 podman image load -i /srv/cray/resources/common/images/ceph-grafana_6.7.4.tar
 podman image load -i /srv/cray/resources/common/images/prometheus_v2.18.1.tar
+podman tag  registry.local/prometheus/prometheus:v2.18.1 registry.local/quay.io/prometheus/prometheus:v2.18.1
 podman image load -i /srv/cray/resources/common/images/alertmanager_v0.20.0.tar
 podman image load -i /srv/cray/resources/common/images/alertmanager_v0.21.0.tar
 podman tag registry.local/prometheus/alertmanager:v0.21.0 registry.local/quay.io/prometheus/alertmanager:v0.21.0


### PR DESCRIPTION
#### Summary and Scope

- Fixes # CASMINST-4682

##### Issue Type

- Bugfix Pull Request

Adding tag to existing image that was missed during the change from pulling upstream containers to algol60

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
n/a
 
#### Risks and Mitigations
 
n/a
