### PR TITLE
VSHA-399 for vshasta get SSH keys from gcp platform metadata

### DIFF
--- a/boxes/ncn-common/files/scripts/google/cloudinit.sh
+++ b/boxes/ncn-common/files/scripts/google/cloudinit.sh
@@ -2,6 +2,14 @@
 
 set -e
 
+echo "Setting up root SSH keys from 'cloud-init' (aka platform metadata)"
+craysys metadata get root-private-key > /root/.ssh/id_rsa
+chmod 600 /root/.ssh/id_rsa
+craysys metadata get root-public-key > /root/.ssh/id_rsa.pub
+chmod 644 /root/.ssh/id_rsa.pub
+cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+chmod 644 /root/.ssh/authorized_keys
+
 echo "Scheduling local DNS server(s) awareness updates for every 5 minutes"
 echo "*/5 * * * * root . /etc/profile.d/cray.sh; /etc/ansible/gcp/bin/python3 /srv/cray/scripts/google/update-dns.py >> /var/log/cray/cron.log 2>&1" > /etc/cron.d/cray-update-dns
 


### PR DESCRIPTION
#### Summary and Scope

- Fixes VSHA-399

##### Issue Type

- Bugfix Pull Request

Add code to `/srv/cray/scripts/google/cloudinit.sh` to obtain SSH keys from GCP project metadata to address the fact that keys are no longer delivered on the built images.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [ N/A ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [x] I tested this on vshasta (if yes, please include results or a description of the test)

Built vshasta images under Jenkins from my branch, rolled a vshasta using the built images and deployed CSM.  Verified that CSM deployment was successful and complete on vshasta.
 
#### Idempotency
 
The code runs at boot and reads data into SSH key files for the `root` account.  The result will be the same each time a node boots with the same project metadata, so the change is idempotent.
 
#### Risks and Mitigations
 
Risk is low for this mod.  The primary issue would be running this change on a vshasta that was deployed with the metadata missing (i.e. an out of data `vshasta` command) which will be addressed as needed by having users update their `vshasta` command installations.  The message has been delivered to all vshasta users that they need to perform that update.  I will manage the stragglers.