### PR TITLE
Add OIDC api-server integration for multi-tenancy

### DIFF
--- a/boxes/ncn-node-images/k8s/files/resources/common/kubeadm.cfg
+++ b/boxes/ncn-node-images/k8s/files/resources/common/kubeadm.cfg
@@ -33,6 +33,12 @@ apiServer:
   extraArgs:
     runtime-config: "apps/v1beta1=true,apps/v1beta2=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
     api-audiences: "api,istio-ca"
+    oidc-issuer-url: "https://${API_GW}/keycloak/realms/shasta"
+    oidc-client-id: "kubernetes-api-oidc-client"
+    oidc-ca-file: "/etc/kubernetes/pki/oidc.pem"
+    oidc-username-claim: "name"
+    oidc-groups-claim: "groups"
+
 controllerManager:
   extraArgs: ${CONTROLLER_MANAGER_EXTRA_ARGS}
   extraVolumes:

--- a/boxes/ncn-node-images/k8s/files/resources/common/tenant-admin.conf
+++ b/boxes/ncn-node-images/k8s/files/resources/common/tenant-admin.conf
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: kubernetes
+  cluster:
+    certificate-authority-data: ${CA_CRT}
+    server: https://${CONTROL_PLANE_ENDPOINT}
+contexts:
+- context:
+    cluster: kubernetes
+    user: tenant-admin
+  name: tenant-admin@kubernetes
+current-context: tenant-admin@kubernetes
+kind: Config
+preferences: {}
+users:
+- name: tenant-admin
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      args:
+      - oidc-login
+      - get-token
+      - --oidc-issuer-url=https://${API_GW}/keycloak/realms/shasta
+      - --oidc-client-id=kubernetes-api-oidc-client
+      - --certificate-authority=/etc/kubernetes/pki/oidc.pem
+      - --skip-open-browser
+      - --grant-type=password
+      command: kubectl
+      env: null

--- a/boxes/ncn-node-images/k8s/files/scripts/google/lib.sh
+++ b/boxes/ncn-node-images/k8s/files/scripts/google/lib.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 export PROJECT_ID=$(craysys metadata get /project-id)
 export NETWORK=$(craysys metadata get /network-interfaces/0/network --level node | awk -F'/' '{print $NF}')
@@ -20,6 +43,8 @@ export ETCD_HOSTNAME=$(hostname | awk -F "-" '{print $1 "-" $2}')
 export ETCD_HA_PORT=2379
 export CONTROL_PLANE_HOSTNAME="kubernetes-api.${DOMAIN}"
 export CONTROL_PLANE_ENDPOINT="${CONTROL_PLANE_HOSTNAME}:6443"
+export API_GW=api-gateway.vshasta.io
+echo "API_GW has been set to $API_GW"
 
 function get-access-token() {
   access_token=$(craysys metadata get /service-accounts/default/token --level node | \
@@ -40,6 +65,8 @@ node-tags = worker
 regional = true
 multizone = true
 EOF
+  echo "Copying /etc/ssl/ca-bundle.pem to /etc/kubernetes/pki/oidc.pem for kube-apiserver"
+  cp /etc/ssl/ca-bundle.pem /etc/kubernetes/pki/oidc.pem
 }
 
 function configure-load-balancer-for-master() {

--- a/boxes/ncn-node-images/k8s/files/scripts/metal/lib.sh
+++ b/boxes/ncn-node-images/k8s/files/scripts/metal/lib.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 ip=$(dig +short $(hostname).nmn)
 cnt=0
@@ -31,6 +54,8 @@ echo "IMAGE_REGISTRY has been set to $IMAGE_REGISTRY"
 export FIRST_STORAGE_HOSTNAME=ncn-s001.nmn
 export ETCD_HOSTNAME=$(hostname)
 export ETCD_HA_PORT=2381
+export API_GW=api-gw-service-nmn.local
+echo "API_GW has been set to $API_GW"
 
 function get_ip_from_metadata() {
   host=$1
@@ -40,8 +65,11 @@ function get_ip_from_metadata() {
 
 function pre-configure-node() {
   echo "In pre-configure-node()"
-  # placeholder; nothing todo right now, remove this note if/when code is
-  # added.
+
+  echo "Copying /etc/ssl/ca-bundle.pem to /etc/kubernetes/pki/oidc.pem for kube-apiserver"
+  mkdir -p /etc/kubernetes/pki
+  cp /etc/ssl/ca-bundle.pem /etc/kubernetes/pki/oidc.pem
+
   return 0
 }
 


### PR DESCRIPTION
#### Summary and Scope

- Fixes https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4301

##### Issue Type

- RFE Pull Request

Add api-server integration for OIDC multi-tenancy, as well as provide kubectl config file for tenant-admin use.

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
- [x] I tested this on craystack (if yes, please include results or a description of the test)

```
ncn-m001:~ # kubectl get nodes
NAME       STATUS   ROLES                  AGE   VERSION
ncn-m001   Ready    control-plane,master   35m   v1.20.13
ncn-m002   Ready    control-plane,master   34m   v1.20.13
ncn-m003   Ready    control-plane,master   34m   v1.20.13
ncn-w001   Ready    <none>                 34m   v1.20.13
ncn-w002   Ready    <none>                 34m   v1.20.13
ncn-w003   Ready    <none>                 34m   v1.20.13
```
 
#### Idempotency
 
This will fix fresh install -- still need same change for upgrade (not image change).
 
#### Risks and Mitigations
 
Low