### PR TITLE
CASMTRIAGE-3391: enable goss-servers

### DIFF
--- a/boxes/ncn-common/files/tests/common/goss-image-common.yaml
+++ b/boxes/ncn-common/files/tests/common/goss-image-common.yaml
@@ -1,3 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
 file:
   /var/adm/autoinstall/cache:
     exists: false

--- a/boxes/ncn-common/files/tests/common/goss-image-common.yaml
+++ b/boxes/ncn-common/files/tests/common/goss-image-common.yaml
@@ -35,6 +35,9 @@ service:
   cloud-final:
     enabled: true
     running: false
+  goss-servers:
+    enabled: true
+    running: true
   issue-generator:
     enabled: true
     running: false

--- a/boxes/ncn-common/provisioners/common/install.sh
+++ b/boxes/ncn-common/provisioners/common/install.sh
@@ -32,6 +32,7 @@ systemctl enable --now lldpad.service
 systemctl disable postfix.service && systemctl stop postfix.service
 systemctl enable chronyd.service
 systemctl enable spire-agent.service
+systemctl enable --now goss-servers
 
 pip3 install --upgrade pip
 pip3 install requests

--- a/boxes/ncn-common/provisioners/common/install.sh
+++ b/boxes/ncn-common/provisioners/common/install.sh
@@ -1,5 +1,28 @@
 #!/bin/bash
 
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
 set -e
 
 echo "Ensuring /srv/cray/utilities locations are available for use system-wide"


### PR DESCRIPTION
#### Summary and Scope

goss-servers starts on boot, but is not enabled. Fix that.

<!--- Pick one below and delete the rest -->

- Fixes CASMTRIAGE-3391

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 